### PR TITLE
Harden NFO identity matching

### DIFF
--- a/crates/scryer-application/src/library/nfo.rs
+++ b/crates/scryer-application/src/library/nfo.rs
@@ -131,6 +131,9 @@ fn parse_xml_nfo(content: &str, meta: &mut NfoMetadata) {
                     current_tag = name.clone();
                     current_text.clear();
                     current_depth = depth;
+                    if name == "id" && root_kind != NfoRootKind::Episode {
+                        apply_id_attribute_provider_ids(e, meta);
+                    }
                     uniqueid_type = e
                         .attributes()
                         .filter_map(|a| a.ok())
@@ -178,14 +181,22 @@ fn parse_xml_nfo(content: &str, meta: &mut NfoMetadata) {
                         "uniqueid" => {
                             if let Some(ref uid_type) = uniqueid_type {
                                 match uid_type.as_str() {
-                                    "tvdb" if meta.tvdb_id.is_none() => {
+                                    "tvdb"
+                                        if root_kind != NfoRootKind::Episode
+                                            && meta.tvdb_id.is_none()
+                                            && looks_like_numeric_id(&text) =>
+                                    {
                                         meta.tvdb_id = Some(text);
                                     }
-                                    "imdb" if meta.imdb_id.is_none() => {
+                                    "imdb"
+                                        if root_kind != NfoRootKind::Episode
+                                            && meta.imdb_id.is_none() =>
+                                    {
                                         meta.imdb_id = normalize_imdb(&text);
                                     }
                                     "tmdb"
-                                        if meta.tmdb_id.is_none()
+                                        if root_kind != NfoRootKind::Episode
+                                            && meta.tmdb_id.is_none()
                                             && looks_like_numeric_id(&text) =>
                                     {
                                         meta.tmdb_id = Some(text);
@@ -194,13 +205,23 @@ fn parse_xml_nfo(content: &str, meta: &mut NfoMetadata) {
                                 }
                             }
                         }
-                        "tvdbid" if meta.tvdb_id.is_none() && looks_like_numeric_id(&text) => {
+                        "tvdbid"
+                            if root_kind != NfoRootKind::Episode
+                                && meta.tvdb_id.is_none()
+                                && looks_like_numeric_id(&text) =>
+                        {
                             meta.tvdb_id = Some(text);
                         }
-                        "imdbid" | "imdb_id" if meta.imdb_id.is_none() => {
+                        "imdbid" | "imdb_id"
+                            if root_kind != NfoRootKind::Episode && meta.imdb_id.is_none() =>
+                        {
                             meta.imdb_id = normalize_imdb(&text);
                         }
-                        "tmdbid" if meta.tmdb_id.is_none() && looks_like_numeric_id(&text) => {
+                        "tmdbid"
+                            if root_kind != NfoRootKind::Episode
+                                && meta.tmdb_id.is_none()
+                                && looks_like_numeric_id(&text) =>
+                        {
                             meta.tmdb_id = Some(text);
                         }
                         "id" if legacy_id.is_none() => {
@@ -233,12 +254,14 @@ fn parse_xml_nfo(content: &str, meta: &mut NfoMetadata) {
     // Apply legacy <id> only if higher-priority tags didn't provide the value.
     // Numeric movie <id> values are intentionally ignored: too many tools have
     // used that field for different providers, so it is not safe identity.
-    if let Some(id_val) = legacy_id {
+    if root_kind != NfoRootKind::Episode
+        && let Some(id_val) = legacy_id
+    {
         if id_val.starts_with("tt") && meta.imdb_id.is_none() {
             meta.imdb_id = normalize_imdb(&id_val);
         } else if looks_like_numeric_id(&id_val) {
             match root_kind {
-                NfoRootKind::TvShow | NfoRootKind::Episode if meta.tvdb_id.is_none() => {
+                NfoRootKind::TvShow if meta.tvdb_id.is_none() => {
                     meta.tvdb_id = Some(id_val);
                 }
                 _ => {}
@@ -246,7 +269,34 @@ fn parse_xml_nfo(content: &str, meta: &mut NfoMetadata) {
         }
     }
 
-    apply_url_ids_from_text(&url_fallback_text, meta);
+    if root_kind != NfoRootKind::Episode {
+        apply_url_ids_from_text(&url_fallback_text, meta);
+    }
+}
+
+fn apply_id_attribute_provider_ids(event: &BytesStart<'_>, meta: &mut NfoMetadata) {
+    for attr in event.attributes().filter_map(|attr| attr.ok()) {
+        let key = String::from_utf8_lossy(attr.key.as_ref()).to_ascii_lowercase();
+        let value = String::from_utf8_lossy(attr.value.as_ref())
+            .trim()
+            .to_string();
+        if value.is_empty() {
+            continue;
+        }
+
+        match key.as_str() {
+            "imdb" if meta.imdb_id.is_none() => {
+                meta.imdb_id = normalize_imdb(&value);
+            }
+            "tmdb" if meta.tmdb_id.is_none() => {
+                meta.tmdb_id = crate::normalize::normalize_numeric_id(&value);
+            }
+            "tvdb" if meta.tvdb_id.is_none() => {
+                meta.tvdb_id = crate::normalize::normalize_numeric_id(&value);
+            }
+            _ => {}
+        }
+    }
 }
 
 pub(crate) fn parse_plexmatch(content: &str) -> NfoMetadata {
@@ -872,6 +922,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_jellyfin_id_attributes() {
+        let nfo = r#"<movie><id TMDB="2502" TVDB="842" IMDB="tt0372183">ignored</id></movie>"#;
+        let meta = parse_nfo(nfo);
+        assert_eq!(meta.tmdb_id, Some("2502".into()));
+        assert_eq!(meta.tvdb_id, Some("842".into()));
+        assert_eq!(meta.imdb_id, Some("tt0372183".into()));
+    }
+
+    #[test]
     fn parse_legacy_id_imdb() {
         let nfo = "<movie><id>tt1234567</id></movie>";
         let meta = parse_nfo(nfo);
@@ -1142,8 +1201,27 @@ Pattern: Bonus/Bonus {sp,1-3,+4}.mp4
   <uniqueid type="tvdb" default="true">349232</uniqueid>
 </episodedetails>"#;
         let meta = parse_nfo(nfo);
-        assert_eq!(meta.tvdb_id, Some("349232".into()));
+        assert_eq!(meta.tvdb_id, None);
         assert_eq!(meta.title, Some("Pilot".into()));
+    }
+
+    #[test]
+    fn parse_episode_details_ids_are_not_title_identity() {
+        let nfo = r#"<episodedetails>
+  <title>Pilot</title>
+  <uniqueid type="tvdb" default="true">349232</uniqueid>
+  <uniqueid type="imdb">tt0959621</uniqueid>
+  <uniqueid type="tmdb">62085</uniqueid>
+  <tvdbid>349232</tvdbid>
+  <imdbid>tt0959621</imdbid>
+  <tmdbid>62085</tmdbid>
+  <id TVDB="349232" IMDB="tt0959621" TMDB="62085">349232</id>
+</episodedetails>"#;
+        let meta = parse_nfo(nfo);
+        assert_eq!(meta.title, Some("Pilot".into()));
+        assert_eq!(meta.tvdb_id, None);
+        assert_eq!(meta.imdb_id, None);
+        assert_eq!(meta.tmdb_id, None);
     }
 
     #[test]

--- a/crates/scryer-application/src/library/scan/metadata.rs
+++ b/crates/scryer-application/src/library/scan/metadata.rs
@@ -55,7 +55,8 @@ impl MetadataIdentityHint {
 
     fn accepts_safe_match(&self, item: &MetadataSearchItem) -> bool {
         !self.has_external_ids()
-            || self.has_matching_external_id_signal(item)
+            || (self.has_matching_external_id_signal(item)
+                && self.external_id_match_is_evidence_compatible(item))
             || self.allows_sidecar_exact_title_year_fallback(item)
     }
 
@@ -63,6 +64,23 @@ impl MetadataIdentityHint {
         (self.imdb_id.is_some() && item.has_auto_match_signal("external_id:imdb"))
             || (self.tmdb_id.is_some() && item.has_auto_match_signal("external_id:tmdb"))
             || (self.tvdb_id.is_some() && item.has_auto_match_signal("external_id:tvdb"))
+    }
+
+    fn external_id_match_is_evidence_compatible(&self, item: &MetadataSearchItem) -> bool {
+        if let Some(hint_year) = self.year
+            && let Some(item_year) = item.year
+        {
+            let Ok(hint_year) = i32::try_from(hint_year) else {
+                return false;
+            };
+            if (hint_year - item_year).abs() > 1 {
+                return false;
+            }
+        }
+
+        self.title
+            .as_deref()
+            .is_none_or(|hint_title| title_evidence_is_compatible(hint_title, &item.name))
     }
 
     fn allows_sidecar_exact_title_year_fallback(&self, item: &MetadataSearchItem) -> bool {
@@ -76,6 +94,44 @@ impl MetadataIdentityHint {
             && item.has_auto_match_signal("exact_title")
             && item.has_auto_match_signal("exact_year")
     }
+}
+
+fn title_evidence_is_compatible(expected: &str, actual: &str) -> bool {
+    let expected = crate::title_matching::canonical_lookup_key(expected);
+    let actual = crate::title_matching::canonical_lookup_key(actual);
+    if expected.is_empty() || actual.is_empty() {
+        return true;
+    }
+    if expected == actual {
+        return true;
+    }
+
+    let distance = levenshtein_distance(&expected, &actual);
+    let max_len = expected.chars().count().max(actual.chars().count());
+    if max_len <= 4 {
+        return false;
+    }
+
+    distance <= 2 || (max_len >= 16 && distance.saturating_mul(100) <= max_len.saturating_mul(18))
+}
+
+fn levenshtein_distance(left: &str, right: &str) -> usize {
+    let right_chars = right.chars().collect::<Vec<_>>();
+    let mut previous = (0..=right_chars.len()).collect::<Vec<_>>();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (left_index, left_char) in left.chars().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_char) in right_chars.iter().enumerate() {
+            let substitution_cost = usize::from(left_char != *right_char);
+            current[right_index + 1] = (previous[right_index + 1] + 1)
+                .min(current[right_index] + 1)
+                .min(previous[right_index] + substitution_cost);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[right_chars.len()]
 }
 
 trait MetadataSearchItemSignals {
@@ -1513,11 +1569,9 @@ async fn build_prepared_movie_library_scan_candidate(
     let query_variants = query_evidence.queries.clone();
     let extracted_year_hint = query_evidence.year;
     let fallback_query = query_variants.first().cloned().unwrap_or_default();
-    let plexmatch_meta =
-        read_plexmatch_metadata(candidate_sidecar_folder(&file.path, &library_path)).await;
     let identity_hint = select_metadata_identity_hint(
         nfo_meta.as_ref(),
-        plexmatch_meta.as_ref(),
+        None,
         query_evidence.file_walk.as_ref(),
         query_evidence.folder_walk.as_ref(),
         &parsed_release,
@@ -2774,6 +2828,79 @@ mod tests {
     }
 
     #[test]
+    fn select_movie_metadata_from_batch_results_rejects_external_id_with_conflicting_evidence() {
+        let mut candidate = build_prepared_movie_candidate(&["The Bourne Supremacy"]);
+        candidate.identity_hint = Some(MetadataIdentityHint {
+            source: MetadataIdentitySource::Nfo,
+            imdb_id: None,
+            tmdb_id: None,
+            tvdb_id: Some("2502".into()),
+            title: Some("The Bourne Supremacy".into()),
+            year: Some(2004),
+        });
+        let key = BatchMetadataSearchKey::new(
+            METADATA_TYPE_MOVIE,
+            "The Bourne Supremacy",
+            None,
+            candidate.identity_hint.as_ref(),
+        )
+        .expect("metadata search key");
+        let mut results = HashMap::new();
+        results.insert(
+            key,
+            Arc::new(vec![MetadataSearchItem {
+                tvdb_id: "2502".into(),
+                name: "Patton".into(),
+                year: Some(1970),
+                auto_match_safe: true,
+                auto_match_signals: vec!["external_id:tvdb".into()],
+            }]),
+        );
+
+        let selected = select_movie_metadata_from_batch_results(&candidate, &results)
+            .expect("movie batch selection");
+
+        assert!(selected.is_none());
+    }
+
+    #[test]
+    fn select_movie_metadata_from_batch_results_accepts_external_id_with_title_nuance() {
+        let mut candidate = build_prepared_movie_candidate(&["Furiosa A Mad Max Saga"]);
+        candidate.identity_hint = Some(MetadataIdentityHint {
+            source: MetadataIdentitySource::Filename,
+            imdb_id: Some("tt12037194".into()),
+            tmdb_id: None,
+            tvdb_id: None,
+            title: Some("Furiosa A Mad Max Saga".into()),
+            year: Some(2024),
+        });
+        let key = BatchMetadataSearchKey::new(
+            METADATA_TYPE_MOVIE,
+            "Furiosa A Mad Max Saga",
+            None,
+            candidate.identity_hint.as_ref(),
+        )
+        .expect("metadata search key");
+        let mut results = HashMap::new();
+        results.insert(
+            key,
+            Arc::new(vec![MetadataSearchItem {
+                tvdb_id: "157390".into(),
+                name: "Furiosa: A Mad Max Saga".into(),
+                year: Some(2024),
+                auto_match_safe: true,
+                auto_match_signals: vec!["external_id:imdb".into()],
+            }]),
+        );
+
+        let selected = select_movie_metadata_from_batch_results(&candidate, &results)
+            .expect("movie batch selection")
+            .expect("compatible ID-backed match");
+
+        assert_eq!(selected.tvdb_id, "157390");
+    }
+
+    #[test]
     fn next_metadata_search_chunk_limits_movie_batch_keys() {
         let candidates = vec![
             build_prepared_movie_candidate(&["Alpha", "Beta"]),
@@ -3051,6 +3178,42 @@ mod tests {
                 .as_ref()
                 .map(|item| item.tvdb_id.as_str())
                 == Some("series-1")
+        }));
+    }
+
+    #[tokio::test]
+    async fn prepare_movie_candidate_ignores_plexmatch_hint() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let folder = tempdir.path().join("The Bourne Supremacy (2004)");
+        std::fs::create_dir_all(&folder).expect("create movie dir");
+        let movie_path = folder.join("The Bourne Supremacy (2004) Remux-1080p.mkv");
+        std::fs::write(&movie_path, b"movie").expect("write movie");
+        std::fs::write(
+            folder.join(".plexmatch"),
+            "title: Patton\nyear: 1970\ntvdbid: 2502\n",
+        )
+        .expect("write plexmatch");
+
+        let candidate = prepare_movie_library_scan_candidate(
+            LibraryFile {
+                path: path_to_stored_string(&movie_path),
+                display_name: "The Bourne Supremacy (2004) Remux-1080p".into(),
+                nfo_path: None,
+                size_bytes: None,
+                source_signature_scheme: None,
+                source_signature_value: None,
+            },
+            path_to_stored_string(tempdir.path()),
+        )
+        .await
+        .expect("prepare movie candidate");
+
+        assert_eq!(candidate.query, "The Bourne Supremacy");
+        assert_eq!(candidate.year_hint, Some(2004));
+        assert!(candidate.identity_hint.as_ref().is_none_or(|hint| {
+            hint.tvdb_id.as_deref() != Some("2502")
+                && hint.title.as_deref() != Some("Patton")
+                && hint.year != Some(1970)
         }));
     }
 


### PR DESCRIPTION
## Summary
- harden NFO identity parsing so provider-specific IDs cannot silently map to the wrong provider
- require provider-specific SMG external-id match signals before accepting ID-backed safe matches
- ignore movie `.plexmatch` while preserving series `.plexmatch`
- prevent episode NFO IDs from becoming top-level movie/series identity evidence

## Root Cause
Movie NFOs from Radarr/Jellyfin can contain bare numeric `<movie><id>` values that are TMDB IDs. Older parsing could treat those as TVDB IDs, allowing rows like TMDB `2502` / Bourne to become TVDB `2502` / Patton after hydration.

## Validation
Passed:
- `rtk cargo test -p scryer-application nfo`
- `rtk cargo test -p scryer-application plexmatch`
- `rtk cargo test -p scryer-application select_movie_metadata_from_batch_results`

Known unrelated failures:
- `rtk cargo test -p scryer-application` fails in backup bundle tests because payload support is not compiled into this target
- the same full run also reproduces three subtitle sidecar test failures unrelated to this two-file hotfix
