### PR TITLE
fix(scan): keep tracked episode files when the library mount is gone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5576,7 +5576,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scryer"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-application"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-domain"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "blake3",
  "chrono",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-acquisition"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-configuration"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-crypto"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-datastore"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-identity"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5840,7 +5840,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-library"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "blake3",
@@ -5873,7 +5873,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-library-search"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "scryer-application",
  "scryer-domain",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-metadata"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-notifications"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-runtime"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -5964,7 +5964,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-sql"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "blake3",
  "chrono",
@@ -5979,7 +5979,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-workflow"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6026,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-acquisition"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6038,7 +6038,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-core"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "scryer-application",
@@ -6049,7 +6049,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-import"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-media"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6083,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-media-types"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-metadata"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "scryer-application",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-query"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "base64 0.22.1",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-security"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-settings"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-subscription"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-system"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6173,14 +6173,14 @@ dependencies = [
 
 [[package]]
 name = "scryer-launcher"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "scryer-logging"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "chrono",
  "serde",
@@ -6191,7 +6191,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-mediainfo"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "bytes",
  "isolang",
@@ -6209,7 +6209,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-mock-apis"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "axum",
  "serde",
@@ -6221,7 +6221,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-outbound-http"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "chrono",
  "governor",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-plugins"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-release-parser"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -6300,7 +6300,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-rules"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "regorus",
  "serde",
@@ -6311,11 +6311,11 @@ dependencies = [
 
 [[package]]
 name = "scryer-runtime-info"
-version = "0.19.15"
+version = "0.19.16"
 
 [[package]]
 name = "scryer-webauthn"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -9026,7 +9026,7 @@ dependencies = [
 
 [[package]]
 name = "xtask-trash-guides"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -657,9 +657,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 dependencies = [
  "serde_core",
 ]
@@ -1843,7 +1843,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
 ]
 
@@ -4063,7 +4063,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-foundation",
 ]
@@ -4074,7 +4074,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "dispatch2",
  "objc2",
 ]
@@ -4091,7 +4091,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4192,9 +4192,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.4.3"
+version = "5.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
+checksum = "aa576c76302b7b808eecc68061e67336c47833ef9d22caa74dda10fa9675eebc"
 dependencies = [
  "is-wsl",
  "libc",
@@ -4330,7 +4330,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a1fae06bd6bc619675d30b50cb38ca649837cc9e6a92a00b14743cfbdb1390"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "ciborium",
  "coset",
  "data-encoding",
@@ -4548,7 +4548,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5082,7 +5082,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -5111,7 +5111,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -5377,7 +5377,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6395,7 +6395,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b04b276c2f79846b7968abe6f87cedf951e06fd2a2b72d99c457e85d7e40f3fb"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "byteorder",
  "bytes",
  "nutype-enum",
@@ -6430,7 +6430,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7023,7 +7023,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "byteorder",
  "bytes",
  "chrono",
@@ -7052,7 +7052,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "byteorder",
  "chrono",
  "crc",
@@ -7608,7 +7608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -7631,7 +7631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
 dependencies = [
  "async-compression",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bytes",
  "futures-core",
  "http",
@@ -7873,9 +7873,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -8033,12 +8033,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.258.0"
+version = "0.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
+checksum = "b1d0246511d901aacf25d2dc9111f0054947de5e093fe662099e709ff7530dc3"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.258.0",
+ "wasmparser 0.259.0",
 ]
 
 [[package]]
@@ -8072,7 +8072,7 @@ version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "hashbrown 0.17.1",
  "indexmap 2.14.2",
  "semver",
@@ -8081,11 +8081,11 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.258.0"
+version = "0.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
+checksum = "0f7c12eac7bb587801590f6a67ff0bc84d0748513864b71108e4b311cc3df694"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "indexmap 2.14.2",
  "semver",
 ]
@@ -8109,7 +8109,7 @@ checksum = "1bd39f78fe9bc82cee4025ec9d52118269e9a1498016cc60119b14f2e1d86a8d"
 dependencies = [
  "addr2line",
  "async-trait",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bumpalo",
  "cc",
  "encoding_rs",
@@ -8317,7 +8317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07429ab53576255be2d298e04b2e1f381e39645465adbaebd69314b5430165c0"
 dependencies = [
  "anyhow",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "heck",
  "indexmap 2.14.2",
  "wit-component",
@@ -8331,7 +8331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85dd81ee95792682ea5b279c9ed352f6b8a2cba084c2f8abdb225e6933323fed"
 dependencies = [
  "async-trait",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bytes",
  "cap-fs-ext",
  "cap-primitives",
@@ -8372,24 +8372,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "258.0.0"
+version = "259.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f7defc7ecca8b19ac7f824598eadd0c53985ee00c74060d65051e9da5b58a1"
+checksum = "c69beba8d9da07af9a0971b559149a2ac4729895b55144de4fddbf5a02660648"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.258.0",
+ "wasm-encoder 0.259.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.258.0"
+version = "1.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7555c008cca87f2ac58d9f83ccda7e7b44611093ce28eb28f052e7c78024b9bf"
+checksum = "c6eec44b0c80391b20fb7ad9ea440c72c5d382385bdf74444bb18321c425017e"
 dependencies = [
- "wast 258.0.0",
+ "wast 259.0.0",
 ]
 
 [[package]]
@@ -8485,7 +8485,7 @@ version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b871ea219ad85c1e59ee7d013563814e86d2e6aa094d3bc66b7675ec4ca58bb7"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "thiserror 2.0.20",
  "tracing",
  "wasmtime",
@@ -8818,7 +8818,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "windows-sys 0.59.0",
 ]
 
@@ -8858,7 +8858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0e65bb94c369b3c4741ce3d1d2704b1fec93db7c540df0e521a097e7ceeb5be"
 dependencies = [
  "anyhow",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "indexmap 2.14.2",
  "log",
  "serde",

--- a/crates/scryer-application/Cargo.toml
+++ b/crates/scryer-application/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-application"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [features]

--- a/crates/scryer-application/src/library/scan/title_scan.rs
+++ b/crates/scryer-application/src/library/scan/title_scan.rs
@@ -68,13 +68,8 @@ async fn discover_episodic_title_files_for_progress(
         &import_paths.folder_template,
         None,
     );
-    if tokio::fs::metadata(&title_dir).await.is_err() {
-        tokio::fs::create_dir_all(&title_dir).await.map_err(|err| {
-            AppError::Repository(format!(
-                "failed to recreate title directory {}: {err}",
-                title_dir.display()
-            ))
-        })?;
+    if !episodic_title_directory_present(&title_dir).await? {
+        return Ok(Vec::new());
     }
     let scan_result = scan_episodic_title_directory_for_progress_metrics(
         app.services.library.library_scanner.clone(),
@@ -82,6 +77,80 @@ async fn discover_episodic_title_files_for_progress(
     )
     .await?;
     Ok(scan_result.files)
+}
+
+/// Whether an episodic title directory exists and can be walked.
+///
+/// An absent directory is never recreated by a scan. Recreating it turned a
+/// vanished library mount into an empty walk that retired every tracked media
+/// file for the title and made every episode wanted again (#208). Whether an
+/// absent directory means "deleted" is decided against the library root by
+/// [`library_root_state`]. Errors other than "not found" (an unreachable
+/// mount, a permission problem) abort the scan so nothing downstream treats
+/// the tree as empty.
+async fn episodic_title_directory_present(title_dir: &Path) -> AppResult<bool> {
+    match tokio::fs::metadata(title_dir).await {
+        Ok(metadata) if metadata.is_dir() => Ok(true),
+        Ok(_) => Err(AppError::Validation(format!(
+            "title directory is not a directory: {}",
+            title_dir.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(AppError::Repository(format!(
+            "failed to inspect title directory {}: {error}",
+            title_dir.display()
+        ))),
+    }
+}
+
+/// What a title's library root looks like when the title directory is absent.
+///
+/// Mirrors Sonarr's series scan: a root that is missing or completely empty is
+/// the signature of a vanished mount, so nothing under it can be called
+/// deleted. Only a populated root makes a missing title directory a real
+/// deletion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LibraryRootState {
+    Missing,
+    Empty,
+    Populated,
+}
+
+async fn library_root_state(root: &Path) -> AppResult<LibraryRootState> {
+    match tokio::fs::metadata(root).await {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => return Ok(LibraryRootState::Missing),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(LibraryRootState::Missing);
+        }
+        Err(error) => {
+            return Err(AppError::Repository(format!(
+                "failed to inspect library root {}: {error}",
+                root.display()
+            )));
+        }
+    }
+    let mut entries = tokio::fs::read_dir(root).await.map_err(|error| {
+        AppError::Repository(format!(
+            "failed to read library root {}: {error}",
+            root.display()
+        ))
+    })?;
+    let has_entry = entries
+        .next_entry()
+        .await
+        .map_err(|error| {
+            AppError::Repository(format!(
+                "failed to read library root {}: {error}",
+                root.display()
+            ))
+        })?
+        .is_some();
+    Ok(if has_entry {
+        LibraryRootState::Populated
+    } else {
+        LibraryRootState::Empty
+    })
 }
 
 async fn discover_movie_title_files(
@@ -223,13 +292,21 @@ async fn discover_movie_title_files(
 }
 
 async fn tracked_movie_path_confirmed_missing(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    tracked_media_path_confirmed_missing(path, parent).await
+}
+
+/// A tracked file counts as missing only when it is gone **and** `anchor_dir`
+/// is still a directory. When the anchor is gone too, the whole tree is
+/// unreachable (a vanished mount, a detached volume) rather than deleted, and
+/// the record must survive so a transient outage never retires real files.
+async fn tracked_media_path_confirmed_missing(path: &Path, anchor_dir: &Path) -> bool {
     match tokio::fs::metadata(path).await {
         Ok(_) => false,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let Some(parent) = path.parent() else {
-                return false;
-            };
-            tokio::fs::metadata(parent)
+            tokio::fs::metadata(anchor_dir)
                 .await
                 .map(|metadata| metadata.is_dir())
                 .unwrap_or(false)
@@ -238,7 +315,7 @@ async fn tracked_movie_path_confirmed_missing(path: &Path) -> bool {
             warn!(
                 error = %error,
                 path = %path.display(),
-                "failed to inspect tracked movie path during stale cleanup"
+                "failed to inspect tracked media path during stale cleanup"
             );
             false
         }
@@ -2060,6 +2137,7 @@ impl AppUseCase {
         }
 
         let import_paths = crate::import_workflow::resolve_import_paths(self, &title).await?;
+        let media_root_path = PathBuf::from(&import_paths.media_root);
         let title_dir = crate::effective_title_folder_path(
             &import_paths.media_root,
             &title,
@@ -2081,17 +2159,24 @@ impl AppUseCase {
         let mut analyze_elapsed = Duration::ZERO;
         let mut db_elapsed = Duration::ZERO;
 
-        if !scoped_discovered_files && tokio::fs::metadata(&title_dir).await.is_err() {
-            tokio::fs::create_dir_all(&title_dir).await.map_err(|err| {
-                AppError::Repository(format!(
-                    "failed to recreate title directory {}: {err}",
-                    title_dir.display()
-                ))
-            })?;
+        // A scoped scan only ever touches the files it was handed, so the
+        // directory itself is irrelevant there. A full-folder scan must know
+        // whether the tree is reachable: when it is not, the scan neither
+        // recreates it nor treats it as empty (see #208).
+        let title_dir_present =
+            scoped_discovered_files || episodic_title_directory_present(&title_dir).await?;
+        if !title_dir_present {
+            debug!(
+                title_id = %title.id,
+                title_name = %title.name,
+                title_dir = %title_dir_str,
+                "title scan stage: title directory is missing; nothing to walk"
+            );
         }
 
         let discovered_files = match pre_scanned_files {
             Some(files) => files,
+            None if !title_dir_present => Vec::new(),
             None => {
                 let scan_result = scan_episodic_title_directory_for_progress_metrics(
                     self.services.library.library_scanner.clone(),
@@ -2186,6 +2271,50 @@ impl AppUseCase {
             .keys()
             .cloned()
             .collect::<HashSet<_>>();
+
+        // The directory a tracked file must be confirmed missing against
+        // before its record is retired. `None` means this scan asserts nothing
+        // about files it did not see: a scoped scan, or a title tree that is
+        // unreachable because the library root is missing or empty.
+        let stale_cleanup_anchor: Option<PathBuf> = if scoped_discovered_files {
+            None
+        } else if title_dir_present {
+            Some(title_dir.clone())
+        } else {
+            match library_root_state(&media_root_path).await? {
+                LibraryRootState::Populated => {
+                    debug!(
+                        title_id = %title.id,
+                        title_name = %title.name,
+                        title_dir = %title_dir_str,
+                        tracked_files = remaining_existing_paths.len(),
+                        "title directory is missing under a populated library root; \
+                         retiring tracked files that are confirmed gone"
+                    );
+                    Some(media_root_path.clone())
+                }
+                LibraryRootState::Missing => {
+                    warn!(
+                        title_id = %title.id,
+                        title_name = %title.name,
+                        library_root = %media_root_path.display(),
+                        tracked_files = remaining_existing_paths.len(),
+                        "library root does not exist; keeping tracked media file records untouched"
+                    );
+                    None
+                }
+                LibraryRootState::Empty => {
+                    warn!(
+                        title_id = %title.id,
+                        title_name = %title.name,
+                        library_root = %media_root_path.display(),
+                        tracked_files = remaining_existing_paths.len(),
+                        "library root is empty; keeping tracked media file records untouched"
+                    );
+                    None
+                }
+            }
+        };
 
         let mut summary = LibraryScanSummary::default();
         let mut layout_summary = TitleScanLayoutSummary::default();
@@ -2558,7 +2687,7 @@ impl AppUseCase {
         if !library_scan_cancel_requested(cancel_token.as_ref()) {
             let mut title_updated_after_scan = false;
 
-            if !scoped_discovered_files {
+            if let Some(anchor_dir) = stale_cleanup_anchor.as_deref() {
                 reconcile_library_scan_unmatched_items(
                     self,
                     &title.facet,
@@ -2573,7 +2702,8 @@ impl AppUseCase {
                     if !stale_path.starts_with(title_dir_str.as_str()) {
                         continue;
                     }
-                    if stored_path_to_path_buf(&record.file_path).exists() {
+                    let record_path = stored_path_to_path_buf(&record.file_path);
+                    if !tracked_media_path_confirmed_missing(&record_path, anchor_dir).await {
                         continue;
                     }
                     let db_started = Instant::now();

--- a/crates/scryer-domain/Cargo.toml
+++ b/crates/scryer-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-domain"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-infrastructure-acquisition/Cargo.toml
+++ b/crates/scryer-infrastructure-acquisition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-acquisition"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 build = "build.rs"

--- a/crates/scryer-infrastructure-configuration/Cargo.toml
+++ b/crates/scryer-infrastructure-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-configuration"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-crypto/Cargo.toml
+++ b/crates/scryer-infrastructure-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-crypto"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-datastore/Cargo.toml
+++ b/crates/scryer-infrastructure-datastore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-datastore"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 build = "build.rs"

--- a/crates/scryer-infrastructure-identity/Cargo.toml
+++ b/crates/scryer-infrastructure-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-identity"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-library-search/Cargo.toml
+++ b/crates/scryer-infrastructure-library-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-library-search"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-library/Cargo.toml
+++ b/crates/scryer-infrastructure-library/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-library"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-metadata/Cargo.toml
+++ b/crates/scryer-infrastructure-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-metadata"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 build = "build.rs"

--- a/crates/scryer-infrastructure-notifications/Cargo.toml
+++ b/crates/scryer-infrastructure-notifications/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-notifications"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-runtime/Cargo.toml
+++ b/crates/scryer-infrastructure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-runtime"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-sql/Cargo.toml
+++ b/crates/scryer-infrastructure-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-sql"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-workflow/Cargo.toml
+++ b/crates/scryer-infrastructure-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-workflow"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-interface-acquisition/Cargo.toml
+++ b/crates/scryer-interface-acquisition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-acquisition"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-core/Cargo.toml
+++ b/crates/scryer-interface-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-core"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-import/Cargo.toml
+++ b/crates/scryer-interface-import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-import"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-media-types/Cargo.toml
+++ b/crates/scryer-interface-media-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-media-types"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-media/Cargo.toml
+++ b/crates/scryer-interface-media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-media"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-metadata/Cargo.toml
+++ b/crates/scryer-interface-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-metadata"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-query/Cargo.toml
+++ b/crates/scryer-interface-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-query"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-security/Cargo.toml
+++ b/crates/scryer-interface-security/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-security"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-settings/Cargo.toml
+++ b/crates/scryer-interface-settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-settings"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-subscription/Cargo.toml
+++ b/crates/scryer-interface-subscription/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-subscription"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-system/Cargo.toml
+++ b/crates/scryer-interface-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-system"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface/Cargo.toml
+++ b/crates/scryer-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-launcher/Cargo.toml
+++ b/crates/scryer-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-launcher"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-logging/Cargo.toml
+++ b/crates/scryer-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-logging"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-mediainfo/Cargo.toml
+++ b/crates/scryer-mediainfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-mediainfo"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-mock-apis/Cargo.toml
+++ b/crates/scryer-mock-apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-mock-apis"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [[bin]]

--- a/crates/scryer-outbound-http/Cargo.toml
+++ b/crates/scryer-outbound-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-outbound-http"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-plugins/Cargo.toml
+++ b/crates/scryer-plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-plugins"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-release-parser/Cargo.toml
+++ b/crates/scryer-release-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-release-parser"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-release-parser/fuzz/Cargo.lock
+++ b/crates/scryer-release-parser/fuzz/Cargo.lock
@@ -255,7 +255,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scryer-release-parser"
-version = "0.19.14"
+version = "0.19.15"
 dependencies = [
  "aho-corasick",
  "chrono",

--- a/crates/scryer-rules/Cargo.toml
+++ b/crates/scryer-rules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-rules"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-runtime-info/Cargo.toml
+++ b/crates/scryer-runtime-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-runtime-info"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-webauthn/Cargo.toml
+++ b/crates/scryer-webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-webauthn"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer/Cargo.toml
+++ b/crates/scryer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 
 [features]

--- a/crates/scryer/tests/integration_out_of_band_library_scan.rs
+++ b/crates/scryer/tests/integration_out_of_band_library_scan.rs
@@ -1018,3 +1018,229 @@ async fn resolving_existing_title_pending_import_does_not_clear_existing_title_f
         Some(title_dir.to_string_lossy().as_ref())
     );
 }
+
+/// A series title with one tracked episode file on disk, for the stale-cleanup
+/// tests below. The synthetic tree is `<root>/<name>/Season 01/<file>.mkv`.
+struct TrackedSeriesFixture {
+    title: Title,
+    title_dir: PathBuf,
+    season_dir: PathBuf,
+}
+
+async fn seed_tracked_series_file(
+    ctx: &TestContext,
+    media_root: &Path,
+    id: &str,
+    name: &str,
+) -> TrackedSeriesFixture {
+    let title_dir = media_root.join(name);
+    let season_dir = title_dir.join("Season 01");
+    let file_path = season_dir.join(format!(
+        "{}.S01E01.1080p.WEB-DL.mkv",
+        name.replace(' ', ".")
+    ));
+    write_fake_media_file(&file_path);
+
+    let title = seed_series_title(
+        ctx,
+        id,
+        name,
+        MediaFacet::Series,
+        media_root,
+        Some(&title_dir),
+        None,
+    )
+    .await;
+    let season = seed_collection(ctx, &title, 1).await;
+    let episode = seed_episode(ctx, &title, &season, 1).await;
+
+    let file_id = ctx
+        .media_files
+        .insert_media_file(&InsertMediaFileInput {
+            title_id: title.id.clone(),
+            file_path: file_path.to_string_lossy().to_string(),
+            size_bytes: 16,
+            announced_size_bytes: None,
+            role: MediaFileRole::Primary,
+            source_signature_scheme: None,
+            source_signature_value: None,
+            quality_label: Some("1080p".to_string()),
+            scene_name: None,
+            release_group: None,
+            source_type: None,
+            resolution: None,
+            video_codec_parsed: None,
+            audio_codec_parsed: None,
+            audio_channels_parsed: None,
+            acquisition_score: None,
+            scoring_log: None,
+            indexer_source: None,
+            grabbed_release_title: None,
+            grabbed_at: None,
+            edition: None,
+            original_file_path: None,
+            release_hash: None,
+        })
+        .await
+        .expect("insert media file");
+    ctx.media_files
+        .link_file_to_episode(&file_id, &episode.id)
+        .await
+        .expect("link file to episode");
+
+    TrackedSeriesFixture {
+        title,
+        title_dir,
+        season_dir,
+    }
+}
+
+async fn tracked_file_count(ctx: &TestContext, title_id: &str) -> usize {
+    ctx.media_files
+        .list_media_files_for_title(title_id)
+        .await
+        .expect("list media files for title")
+        .len()
+}
+
+async fn bootstrap_tracked_series(
+    ctx: &TestContext,
+    media_root: &Path,
+    id: &str,
+    name: &str,
+) -> TrackedSeriesFixture {
+    seed_media_path_settings(ctx).await;
+    set_media_path(ctx, "series.path", media_root.to_string_lossy().as_ref()).await;
+    set_default_library_root(ctx, MediaFacet::Series, media_root).await;
+
+    let fixture = seed_tracked_series_file(ctx, media_root, id, name).await;
+
+    let baseline = ctx
+        .app
+        .scan_title_library(&admin(), &fixture.title.id)
+        .await
+        .expect("baseline title scan");
+    assert_eq!(baseline.scanned, 1);
+    assert_eq!(tracked_file_count(ctx, &fixture.title.id).await, 1);
+
+    fixture
+}
+
+/// The library mount is gone: the media root itself no longer exists. The scan
+/// must neither recreate the tree nor retire the tracked file (#208).
+#[tokio::test]
+async fn title_scan_keeps_tracked_files_when_library_root_vanishes() {
+    let ctx = TestContext::new().await;
+    let media_root = tempfile::tempdir().expect("series root");
+    let fixture =
+        bootstrap_tracked_series(&ctx, media_root.path(), "title-root-gone", "Root Gone Show")
+            .await;
+
+    std::fs::remove_dir_all(media_root.path()).expect("simulate vanished library mount");
+
+    let summary = ctx
+        .app
+        .scan_title_library(&admin(), &fixture.title.id)
+        .await
+        .expect("title scan with vanished root");
+
+    assert_eq!(summary.scanned, 0);
+    assert_eq!(tracked_file_count(&ctx, &fixture.title.id).await, 1);
+    assert!(
+        !fixture.title_dir.exists(),
+        "scan must not recreate the title directory"
+    );
+    assert!(
+        !media_root.path().exists(),
+        "scan must not recreate the library root"
+    );
+}
+
+/// The root directory is still there but has nothing in it, which is what a
+/// dead mount point looks like. Like Sonarr, the scan treats an empty root as
+/// unreachable: records are kept and the directory is not recreated.
+#[tokio::test]
+async fn title_scan_keeps_tracked_files_when_title_directory_vanishes_from_an_empty_root() {
+    let ctx = TestContext::new().await;
+    let media_root = tempfile::tempdir().expect("series root");
+    let fixture =
+        bootstrap_tracked_series(&ctx, media_root.path(), "title-dir-gone", "Dir Gone Show").await;
+
+    std::fs::remove_dir_all(&fixture.title_dir).expect("remove title directory");
+    assert!(
+        std::fs::read_dir(media_root.path())
+            .expect("read root")
+            .next()
+            .is_none(),
+        "fixture root must be empty"
+    );
+
+    let summary = ctx
+        .app
+        .scan_title_library(&admin(), &fixture.title.id)
+        .await
+        .expect("title scan with missing title directory");
+
+    assert_eq!(summary.scanned, 0);
+    assert_eq!(tracked_file_count(&ctx, &fixture.title.id).await, 1);
+    assert!(
+        !fixture.title_dir.exists(),
+        "scan must not recreate the title directory"
+    );
+}
+
+/// The root is populated with other content and only this title's directory is
+/// gone: that is a deliberate deletion, so the records are retired and the
+/// episode becomes wanted again. The directory is still not recreated.
+#[tokio::test]
+async fn title_scan_retires_tracked_files_when_title_directory_is_deleted_under_a_populated_root() {
+    let ctx = TestContext::new().await;
+    let media_root = tempfile::tempdir().expect("series root");
+    let fixture =
+        bootstrap_tracked_series(&ctx, media_root.path(), "title-deleted", "Deleted Show").await;
+    std::fs::create_dir_all(media_root.path().join("Neighbour Show"))
+        .expect("create sibling title directory");
+
+    std::fs::remove_dir_all(&fixture.title_dir).expect("remove title directory");
+
+    let summary = ctx
+        .app
+        .scan_title_library(&admin(), &fixture.title.id)
+        .await
+        .expect("title scan after title directory deletion");
+
+    assert_eq!(summary.scanned, 0);
+    assert_eq!(tracked_file_count(&ctx, &fixture.title.id).await, 0);
+    assert!(
+        !fixture.title_dir.exists(),
+        "scan must not recreate the title directory"
+    );
+}
+
+/// A season folder deleted underneath an intact title directory is a real
+/// deletion: the title tree was walked and the file is confirmed gone, so the
+/// record is retired and the episode becomes wanted again.
+#[tokio::test]
+async fn title_scan_retires_tracked_files_when_season_directory_is_deleted() {
+    let ctx = TestContext::new().await;
+    let media_root = tempfile::tempdir().expect("series root");
+    let fixture = bootstrap_tracked_series(
+        &ctx,
+        media_root.path(),
+        "title-season-gone",
+        "Season Gone Show",
+    )
+    .await;
+
+    std::fs::remove_dir_all(&fixture.season_dir).expect("remove season directory");
+
+    let summary = ctx
+        .app
+        .scan_title_library(&admin(), &fixture.title.id)
+        .await
+        .expect("title scan after season deletion");
+
+    assert_eq!(summary.scanned, 0);
+    assert_eq!(tracked_file_count(&ctx, &fixture.title.id).await, 0);
+    assert!(fixture.title_dir.is_dir());
+}

--- a/release-notes/scryer-v0.19.16.md
+++ b/release-notes/scryer-v0.19.16.md
@@ -1,0 +1,15 @@
+# Scryer 0.19.16 release notes
+
+## Highlights
+
+- A series library whose mount disappears no longer loses its tracked files. Before this release an episodic title scan recreated a missing title directory, walked the empty result and retired every media file record for the title, which made every episode wanted again and could start a mass re-download after a transient mount problem. This closes issue #208. The series scan now follows the same rules Sonarr applies: a library root that is missing or completely empty is treated as unreachable and the title's records are left alone.
+
+## Included fixes
+
+- A title scan never creates the title directory. When the directory is absent and the library root is missing or empty, the scan walks nothing, keeps the title's media file records and unmatched-file rows untouched, and logs one warning naming the title, the root and how many tracked files it kept. A root or title directory that cannot be inspected at all (an unreachable mount, a permission error) fails the scan instead of being treated as empty.
+- Deleting a title directory underneath a populated library root is still recognised as a real deletion: its tracked files are retired on the next scan and the episodes become wanted again, exactly as before, but the empty directory is no longer recreated.
+- A tracked episode file is retired only when the file is gone and the directory it is confirmed against is still present. Deleting a season folder or a single file underneath an intact title directory is cleaned up as before.
+
+## Upgrading
+
+No migration. No configuration changes.

--- a/xtask-trash-guides/Cargo.toml
+++ b/xtask-trash-guides/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask-trash-guides"
-version = "0.19.15"
+version = "0.19.16"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
The episodic title scan recreated a missing title directory, walked the empty result and retired every media file record for the title on a bare exists() check, so a vanished mount made every episode wanted again (#208). The movie scan already guarded against this.

A scan no longer creates the title directory. When the directory is absent the scan consults the library root, following Sonarr's series scan: a missing or empty root is treated as unreachable and the title's records are left alone with a warning; a populated root makes the missing directory a real deletion and the records are retired as before. Records under a present title directory are retired only when the file is confirmed gone against a directory that still exists, and the movie guard now shares that helper. Filesystem errors other than not-found fail the scan instead of reading as an empty tree.

Closes #208.