### PR TITLE
Release 0.19.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5821,6 +5821,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-util",
+ "percent-encoding",
  "quick-xml",
  "reqwest",
  "scryer-application",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,18 +823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-fs-ext"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes 3.0.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "cap-primitives"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,27 +1199,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9903e767cc0a95a59950de099a6b1d61e1476f774be1cdfa06d7ccdc9bfae56f"
+checksum = "42c0ca95f115597232c3c5d7286bf847d49332bee5934749f40808b7fe0c6312"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e777252ea3ec9daffa71408fbfe0793ab0a7b7bc3b2cf0f417dd0fa33964b8ef"
+checksum = "fdd7d59ef8a52c82ea2ac2ca96aee3c52644845440f70611b573bc20ce37e6a2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7828208a36e6627481cea61bd24c6234e31411d5c58b48e80ca094a1d593b944"
+checksum = "547433a3f4204f0ed0f5a5e3ffaf086a0c005fd0efdf040098083f38572e8a49"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1239,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58c8447cc59ef98c49096679f81392ad0acec2224cea2bef52011f5169f9d02"
+checksum = "61ca4f30f5f2eb3837b6e73664d9c0c9a42c4c0dce05f0027f2f2af54c1b20d7"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1250,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce520e899df1de583e7b564eafd66760fbc147d72894d2278ddac57a1489fcc0"
+checksum = "effcb11ccea65cfb2b8dd4f53b92c6449ad37745504bae036bffda597a5cfa48"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1281,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8ab23e63d78ea6bbda18ae1ed9c958bc1cb88d90fb5e95f5ba62e9c019474b"
+checksum = "2cd5b4e429e24f7fd0bfe15d653ec5841fc1831ef68521b0d30182ef0d48bd01"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1294,24 +1282,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24319a996b1ef40ebf8af69b39c868c790b35a42cfe38edacfd8c9deb75ea712"
+checksum = "a8aefe7ed05aa9a831a4696f55e020a6c93998325a09c642863f0be7845fe3a8"
 
 [[package]]
 name = "cranelift-control"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9856d68cc2cefb83229cb2c55b620dd38427555c2fe87d73f8a4421616f628"
+checksum = "b3ceaa06b6ece027bb001093bf0c6984a96281e061fd40a99c60bae0ec57171d"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec225d6b79c5d61358cb5ea081a1384ec541dbf8c1a8c618d187875af326ad"
+checksum = "bc2c3088c6be94765abea42eccff7ac2b6519488e66bb5159febabcf539afd6e"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1321,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3a96a09bd9bd3cf6df2de2ea15d7418f493e946a8eaa1acfe39297a67ed3f3"
+checksum = "0e2c4a0a90aedfa88408f33e65eda7b1f73de0af20ebec516c004b3a1cdc602b"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1334,15 +1322,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd28f593c36afbdc9aa17305c0bb66c39ce0530e1caffcf389fbec053950083e"
+checksum = "bcb1cc85ccb60cfc53c3d55e23196fef28ae78fbcebe4e1ff3ff866a3c93d61c"
 
 [[package]]
 name = "cranelift-native"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2987ca47affc261aa31ac643fb80dd7f8274cebf878003ba9f50cd6ff2c1055f"
+checksum = "5a0a8f5d008c1f5b78426e83028f7517295f6819b5cebe8193949e1bb66cc01a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1351,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.135.1"
+version = "0.135.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7431dd8c9def94aca43b27915dee0d42103d9b13922cfb044febcd975547d68"
+checksum = "56caa8a7f1e0f2c61400996cc1567fb06dd417c49d5e673131a149cb9628625f"
 
 [[package]]
 name = "crc"
@@ -1962,7 +1950,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.5+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -3475,9 +3463,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+checksum = "6480ccc157a1389bb2e4891b24751b0f798ba640d22386f23143fbcc89da195a"
 dependencies = [
  "libc",
 ]
@@ -4788,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f755d75e0809a4738a3e4880eeeb852fadbe1de5a437505b84f09c381657012a"
+checksum = "6e95d890afdd44c1269bdc84e9f043c3a6c02e8bfd1781d64468e62f05880c83"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4800,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e69fa1c4a555946f82e7894a7df88b0e9ee03b4266829b4811467c616ce51d"
+checksum = "550c64f4245f013664d187a37ec94b4e99bd43a00980134e0e5fd48896b1d3af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5624,7 +5612,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "toml 1.1.5+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "tower",
  "tower-http 0.7.1",
  "tracing",
@@ -5739,7 +5727,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "toml 1.1.5+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
@@ -5805,7 +5793,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "tokio",
- "toml 1.1.5+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -6205,7 +6193,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "toml 1.1.5+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
 ]
 
 [[package]]
@@ -6840,9 +6828,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 dependencies = [
  "serde",
 ]
@@ -7493,9 +7481,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap 2.14.2",
  "serde_core",
@@ -7526,9 +7514,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
+version = "0.25.15+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+checksum = "1340ea94a5856333492c9064b02c778b191dd2c853778d9609debdcdfea3a614"
 dependencies = [
  "indexmap 2.14.2",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -8104,9 +8092,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd39f78fe9bc82cee4025ec9d52118269e9a1498016cc60119b14f2e1d86a8d"
+checksum = "699c2cb832d70d284b2839ebeb12721ca2ef80aa4a3389d2d2d13acf3e19c821"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -8146,9 +8134,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c1070d95484d048994ec109cd42c4932ac07e6ee3cc1886fb90c7a18ec29da"
+checksum = "13f10ef166b4850535bc43c347797364cda5189870be163a617ebe5c0d72f139"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -8177,9 +8165,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d447fd40f3e149cda8c0cd808660a1d1de438f3ff28627abb9bcda90dfb4895"
+checksum = "f6e6198ced397a98ebbc95dc8085f73e4bab8c12cae66c179a04c859a69677b3"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -8197,9 +8185,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d2b2f9f89a65bb2277d82fbdd49263d27d8233bc717d750c4b13a23d57721c"
+checksum = "5af067a5d17e17a424f99d31f08e08c5132dcc53a0f031a7be9279719a936b71"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8212,15 +8200,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fe8292115fda08875f29064ae9f7f0b2c1ffbb323146eae538ae34b8a613f"
+checksum = "540b7151342d75c3d596447c136d3862a280600bc6fd10b5dfc7c9e67c2f719f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821385794cf44baf2967fd2515368429ed2bff9b9b256f62d09a0f1301474fd8"
+checksum = "8679b612a408274d91d1e0edf6baa36b63cc48d937f84dd1e7fb2fbe16a907ae"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -8229,9 +8217,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0238b4a52773457ad1b8a1a26be90486e0ca0108cf46b9be16cc1d8d8cabdfa1"
+checksum = "fc46c460fb62d839ac441ccdf4b8b94bce30842ad4ccefd7744d9e28bf631232"
 dependencies = [
  "cranelift-codegen",
  "cranelift-control",
@@ -8255,9 +8243,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596f1d85e06cbf9c9add9c78ea135171c5753264ffe94a83dcc082a1ff49fc9b"
+checksum = "31a94596377490aa56f5c58ebbcc39af49176dd9d4051a78e3fca3c024daf4f6"
 dependencies = [
  "cc",
  "libc",
@@ -8269,9 +8257,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365faed74827bb0116785bab5872372df1baaec9ec0003c83bc99ccdc595f689"
+checksum = "70026f001b46af7552ce89cfe748f0dea59097e7c8c3740998d8019b73d87ee5"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -8279,9 +8267,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cce25afd9e7ac4957292a5c6a219951dd0f140b8417e7378a97f50b67c3b96f"
+checksum = "bf7d8a6fc6d21eb177c38f096636661ca13ae924cccbb6f447c1498ca972ab10"
 dependencies = [
  "libc",
  "wasmtime-internal-core",
@@ -8290,9 +8278,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fdea09d51e39c774984ca68a7d7486767e5b2935f5e686fa654aabcfc3c42d"
+checksum = "4994aca882a65d2b06a7fc57a4a149de27b8851738d07ea2e778a21f74234a14"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -8302,9 +8290,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e48a5f514c38c2f74249724cb3501e45548d3311ca9e3881694859fd6ba116"
+checksum = "8f325614219c58c9f625b591ac79dbbefc76728720d72a721a6350c872d848e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8313,9 +8301,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07429ab53576255be2d298e04b2e1f381e39645465adbaebd69314b5430165c0"
+checksum = "4ec33585b420181c41e26ac6153f0d18aa200e6aba9457dff6f8ebba3feedf98"
 dependencies = [
  "anyhow",
  "bitflags 2.13.2",
@@ -8327,18 +8315,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dd81ee95792682ea5b279c9ed352f6b8a2cba084c2f8abdb225e6933323fed"
+checksum = "ca7a1fae91151d1213fc53e1c2f635a22ca33692fbda4018f13e1ddb6396014d"
 dependencies = [
  "async-trait",
  "bitflags 2.13.2",
  "bytes",
- "cap-fs-ext",
  "cap-primitives",
  "futures",
  "rand 0.10.2",
  "rustix",
+ "rustix-linux-procfs",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -8347,13 +8335,14 @@ dependencies = [
  "wasmtime-wasi-io",
  "wiggle",
  "windows-sys 0.61.2",
+ "winx",
 ]
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a557bc8a7232cd079f6b423a9bb385f3ff9148824f3c26c07a028b499fab2bf"
+checksum = "8b25067b7e9f9f99b8688477fa33bc1883035070da7ebc24b4a4844e97cc9145"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8482,9 +8471,9 @@ checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 
 [[package]]
 name = "wiggle"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b871ea219ad85c1e59ee7d013563814e86d2e6aa094d3bc66b7675ec4ca58bb7"
+checksum = "002e6d7e0b03be510904ded45f8519de70d6b35612b91aaa8f690ee72903c941"
 dependencies = [
  "bitflags 2.13.2",
  "thiserror 2.0.20",
@@ -8496,9 +8485,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed981675756e748a4725286a4059c9be006749a8db4120d54e2021d0f167bac3"
+checksum = "bb5ae7980829d9a4ef554db0a6fa229bffcb3f7373b26436fbf8c40611b84fa6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -8510,9 +8499,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "48.0.1"
+version = "48.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3927729af874585c58b85710128e40d459a7064bb9aea9b0b420fb5eafd555"
+checksum = "fdabe565e5c7917c24d94a4b9537681c2bd5db0d7467a34b710b0036218066f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9011,7 +9000,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml 1.1.5+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "toml_edit",
  "x509-cert 0.3.0",
  "xtask-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,7 +5564,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scryer"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-application"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-domain"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "blake3",
  "chrono",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-acquisition"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-configuration"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-crypto"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-datastore"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-identity"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-library"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "blake3",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-library-search"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "scryer-application",
  "scryer-domain",
@@ -5873,7 +5873,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-metadata"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-notifications"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-runtime"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -5953,7 +5953,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-sql"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "blake3",
  "chrono",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-infrastructure-workflow"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-acquisition"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-core"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "scryer-application",
@@ -6038,7 +6038,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-import"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-media"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-media-types"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6082,7 +6082,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-metadata"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "scryer-application",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-query"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "base64 0.22.1",
@@ -6110,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-security"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-settings"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-subscription"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-interface-system"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -6162,14 +6162,14 @@ dependencies = [
 
 [[package]]
 name = "scryer-launcher"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "scryer-logging"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "chrono",
  "serde",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-mediainfo"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "bytes",
  "isolang",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-mock-apis"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "axum",
  "serde",
@@ -6210,7 +6210,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-outbound-http"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "chrono",
  "governor",
@@ -6236,7 +6236,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-plugins"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -6275,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-release-parser"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "scryer-rules"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "regorus",
  "serde",
@@ -6300,11 +6300,11 @@ dependencies = [
 
 [[package]]
 name = "scryer-runtime-info"
-version = "0.19.16"
+version = "0.19.17"
 
 [[package]]
 name = "scryer-webauthn"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "xtask-trash-guides"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/scryer-application/Cargo.toml
+++ b/crates/scryer-application/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-application"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [features]

--- a/crates/scryer-application/src/folder_ownership.rs
+++ b/crates/scryer-application/src/folder_ownership.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use scryer_domain::Title;
 
-use crate::stored_paths::{folder_paths_match, path_to_stored_string};
+use crate::library::workflow::{LibraryRootState, library_root_state};
+use crate::stored_paths::{folder_paths_match, path_to_stored_string, stored_path_to_path_buf};
 use crate::{AppError, AppResult, AppUseCase};
 
 fn non_empty_folder_path(path: Option<&str>) -> Option<&str> {
@@ -19,6 +20,78 @@ pub(crate) fn title_owns_folder(title: &Title, folder_path: &Path) -> bool {
 pub(crate) fn title_owns_another_folder(title: &Title, folder_path: &Path) -> bool {
     non_empty_folder_path(title.folder_path.as_deref()).is_some()
         && !title_owns_folder(title, folder_path)
+}
+
+/// Whether the folder a title records as its own is still on disk.
+///
+/// `None` means the answer is unknown (an unreachable mount, a permission
+/// problem). Callers treat that as "not proven" and take no action on it.
+async fn owned_folder_present(owned_path: &str) -> Option<bool> {
+    match tokio::fs::metadata(stored_path_to_path_buf(owned_path)).await {
+        Ok(_) => Some(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some(false),
+        Err(_) => None,
+    }
+}
+
+/// A title's recorded folder is stale when it no longer exists while the
+/// directory that held it still has entries.
+///
+/// `folder_path` is written once when a title first claims a folder and is
+/// never re-validated, so files relocated outside Scryer (a root split, a
+/// drive migration, another tool's root-folder move) leave every affected
+/// title pointing at a folder that is gone. The parent-directory check mirrors
+/// the mount guard in [`library_root_state`]: a missing or empty parent is the
+/// signature of a vanished mount, and nothing under it can be called gone.
+pub(crate) async fn title_folder_is_stale(title: &Title) -> bool {
+    let Some(owned_path) = non_empty_folder_path(title.folder_path.as_deref()) else {
+        return false;
+    };
+    if owned_folder_present(owned_path).await != Some(false) {
+        return false;
+    }
+    let owned_path = stored_path_to_path_buf(owned_path);
+    let Some(parent) = owned_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    else {
+        return false;
+    };
+    matches!(
+        library_root_state(parent).await,
+        Ok(LibraryRootState::Populated)
+    )
+}
+
+/// Move a title's stale folder ownership to the folder a scan found its
+/// files in. Returns `false`, changing nothing, when another title already
+/// owns that folder — that is a real conflict, not a heal.
+pub(crate) async fn reclaim_stale_title_folder(
+    app: &AppUseCase,
+    title: &mut Title,
+    folder_path: &Path,
+) -> AppResult<bool> {
+    let previous_folder_path = title.folder_path.clone().unwrap_or_default();
+    let folder_path = path_to_stored_string(folder_path);
+    if find_other_folder_owner(app, title, &folder_path)
+        .await?
+        .is_some()
+    {
+        return Ok(false);
+    }
+    app.services
+        .catalog
+        .titles
+        .set_folder_path(&title.id, &folder_path)
+        .await?;
+    title.folder_path = Some(folder_path.clone());
+    tracing::info!(
+        title_id = %title.id,
+        previous_folder_path = %previous_folder_path,
+        folder_path = %folder_path,
+        "re-pointed stale title folder ownership to the scanned folder"
+    );
+    Ok(true)
 }
 
 async fn find_other_folder_owner(
@@ -120,6 +193,14 @@ pub(crate) async fn unlink_title_media_in_folder(
     folder_path: &Path,
 ) -> AppResult<u32> {
     if !title_owns_another_folder(title, folder_path) {
+        return Ok(0);
+    }
+    // Only a title whose owned folder is confirmed on disk holds a real
+    // second copy. An absent or unreachable owned folder is stale ownership
+    // or an unmounted root; unlinking there turns a monitored title fileless
+    // and exposes it to automatic re-download.
+    let owned_path = title.folder_path.as_deref().unwrap_or_default();
+    if owned_folder_present(owned_path).await != Some(true) {
         return Ok(0);
     }
 

--- a/crates/scryer-application/src/lib_tests/libraries.rs
+++ b/crates/scryer-application/src/lib_tests/libraries.rs
@@ -2161,3 +2161,70 @@ async fn catalog_admin_can_open_titles_in_library_created_after_grant_seeding() 
         other => panic!("expected unauthorized without a grant, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn delete_preview_checks_the_title_folder_against_its_own_library_roots() {
+    let (app, user) = bootstrap();
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let library = app
+        .create_library(
+            &user,
+            MediaFacet::Anime,
+            "Anime Archive".to_string(),
+            vec![LibraryRootDraft {
+                path: tempdir.path().to_string_lossy().to_string(),
+                is_default: true,
+            }],
+            None,
+        )
+        .await
+        .expect("create a non-default anime library");
+    let title_dir = tempdir.path().join("Archived Serial");
+    std::fs::create_dir(&title_dir).expect("create title folder");
+    std::fs::write(
+        title_dir.join("Archived Serial - S01E01.mkv"),
+        vec![0_u8; 64],
+    )
+    .expect("write episode file");
+    let created = app
+        .create_title_without_hydration_in_library(
+            &user,
+            NewTitle {
+                name: "Archived Serial".into(),
+                facet: MediaFacet::Anime,
+                monitored: false,
+                ..Default::default()
+            },
+            library.id.clone(),
+        )
+        .await
+        .expect("create title in the non-default library");
+    app.services
+        .catalog
+        .titles
+        .set_folder_path(&created.title.id, title_dir.to_string_lossy().as_ref())
+        .await
+        .expect("set title folder");
+
+    // The folder sits under the title's own library root, not under the
+    // facet default library's root; the guard has to look at the former.
+    let preview = app
+        .preview_delete_title_files(&user, &created.title.id)
+        .await
+        .expect("preview a delete under the title's own library root");
+    assert_eq!(preview.media_count, 1);
+
+    let bulk = app
+        .preview_delete_titles_files(&user, std::slice::from_ref(&created.title.id))
+        .await
+        .expect("bulk preview");
+    assert_eq!(bulk.items.len(), 1);
+    assert_eq!(bulk.items[0].error, None);
+    assert_eq!(
+        bulk.items[0]
+            .preview
+            .as_ref()
+            .map(|preview| preview.media_count),
+        Some(1)
+    );
+}

--- a/crates/scryer-application/src/lib_tests/library_scan.rs
+++ b/crates/scryer-application/src/lib_tests/library_scan.rs
@@ -2301,6 +2301,10 @@ async fn series_full_scan_records_case_distinct_folder_as_ownership_conflict() {
     let owned_folder = tempdir.path().join("CASE SPLIT FIXTURE");
     let candidate_folder = tempdir.path().join("Case Split Fixture");
     std::fs::create_dir(&candidate_folder).expect("create case-distinct series folder");
+    // The owned folder has to be on disk for this to be a conflict rather
+    // than stale ownership. On a case-insensitive filesystem it aliases the
+    // candidate folder, which still reads as present.
+    let _ = std::fs::create_dir(&owned_folder);
     let episode_path = candidate_folder.join("Case Split Fixture - S01E01.mkv");
     std::fs::write(&episode_path, vec![0_u8; 128]).expect("write episode file");
 
@@ -2377,6 +2381,226 @@ async fn series_full_scan_records_case_distinct_folder_as_ownership_conflict() {
             .expect("list media files")
             .is_empty()
     );
+}
+
+#[tokio::test]
+async fn movie_full_scan_repoints_stale_folder_ownership_to_the_scanned_folder() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let previous_root = tempfile::tempdir().expect("previous root");
+    // The previous root still holds other movies, so the missing owned
+    // folder is a relocation rather than an unmounted drive.
+    std::fs::create_dir(previous_root.path().join("Remaining Feature (2020)"))
+        .expect("create remaining movie folder");
+    let stale_folder = previous_root.path().join("Relocated Feature (2024)");
+    let movie_dir = tempdir.path().join("Relocated Feature (2024)");
+    std::fs::create_dir(&movie_dir).expect("create relocated movie folder");
+    let movie_path = movie_dir.join("Relocated.Feature.2024.1080p.WEB-DL.mkv");
+    std::fs::write(&movie_path, vec![0_u8; 256]).expect("write movie file");
+
+    let (app, user, unmatched_items) = bootstrap_movie_scan_app(
+        tempdir.path(),
+        build_test_library_files(&[movie_path.as_path()]),
+        Arc::new(FixedBatchSearchMetadataGateway {
+            results: vec![MetadataSearchItem {
+                tvdb_id: "445566".to_string(),
+                smg_id: None,
+                primary_source: None,
+                external_ids: vec![],
+                name: "Relocated Feature".to_string(),
+                year: Some(2024),
+                auto_match_safe: true,
+                auto_match_signals: vec!["exact_title".into(), "exact_year".into()],
+            }],
+        }),
+    )
+    .await;
+    let title =
+        create_movie_title_with_folder(&app, &user, "Relocated Feature", stale_folder.as_path())
+            .await;
+
+    let summary = app
+        .scan_library(&user, MediaFacet::Movie)
+        .await
+        .expect("scan movie library");
+
+    assert_eq!(summary.unmatched, 0);
+    assert!(unmatched_items.items().await.is_empty());
+    let healed = app
+        .services
+        .catalog
+        .titles
+        .get_by_id(&title.id)
+        .await
+        .expect("load title")
+        .expect("title exists");
+    assert_eq!(
+        healed.folder_path.as_deref(),
+        Some(movie_dir.to_string_lossy().as_ref())
+    );
+    let files = app
+        .services
+        .library
+        .media_files
+        .list_media_files_for_title(&title.id)
+        .await
+        .expect("list media files");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].file_path, movie_path.to_string_lossy());
+}
+
+#[tokio::test]
+async fn movie_full_scan_keeps_ownership_when_the_owned_root_is_unmounted() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    // Nothing exists under the previous root: the signature of a vanished
+    // mount, not of a relocation.
+    let stale_folder = tempdir
+        .path()
+        .join("unmounted-root")
+        .join("Unmounted Feature (2024)");
+    let movie_dir = tempdir.path().join("Unmounted Feature (2024)");
+    std::fs::create_dir(&movie_dir).expect("create movie folder");
+    let movie_path = movie_dir.join("Unmounted.Feature.2024.1080p.WEB-DL.mkv");
+    std::fs::write(&movie_path, vec![0_u8; 256]).expect("write movie file");
+
+    let (app, user, unmatched_items) = bootstrap_movie_scan_app(
+        tempdir.path(),
+        build_test_library_files(&[movie_path.as_path()]),
+        Arc::new(FixedBatchSearchMetadataGateway {
+            results: vec![MetadataSearchItem {
+                tvdb_id: "556677".to_string(),
+                smg_id: None,
+                primary_source: None,
+                external_ids: vec![],
+                name: "Unmounted Feature".to_string(),
+                year: Some(2024),
+                auto_match_safe: true,
+                auto_match_signals: vec!["exact_title".into(), "exact_year".into()],
+            }],
+        }),
+    )
+    .await;
+    let title =
+        create_movie_title_with_folder(&app, &user, "Unmounted Feature", stale_folder.as_path())
+            .await;
+    app.services
+        .library
+        .media_files
+        .insert_media_file(&InsertMediaFileInput {
+            title_id: title.id.clone(),
+            file_path: movie_path.to_string_lossy().to_string(),
+            size_bytes: 256,
+            role: MediaFileRole::Primary,
+            ..Default::default()
+        })
+        .await
+        .expect("seed catalog row in the scanned folder");
+
+    let summary = app
+        .scan_library(&user, MediaFacet::Movie)
+        .await
+        .expect("scan movie library");
+
+    assert_eq!(summary.unmatched, 1);
+    let unmatched = unmatched_items.items().await;
+    assert_eq!(unmatched.len(), 1);
+    assert_eq!(
+        unmatched[0].reason_code,
+        crate::library_scan_unmatched::LIBRARY_SCAN_TITLE_ALREADY_OWNS_ANOTHER_FOLDER
+    );
+    assert_eq!(unmatched[0].title_id.as_ref(), Some(&title.id));
+    let unchanged = app
+        .services
+        .catalog
+        .titles
+        .get_by_id(&title.id)
+        .await
+        .expect("load title")
+        .expect("title exists");
+    assert_eq!(
+        unchanged.folder_path.as_deref(),
+        Some(stale_folder.to_string_lossy().as_ref())
+    );
+    // The owned folder was never confirmed on disk, so nothing is unlinked.
+    let files = app
+        .services
+        .library
+        .media_files
+        .list_media_files_for_title(&title.id)
+        .await
+        .expect("list media files");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].file_path, movie_path.to_string_lossy());
+}
+
+#[tokio::test]
+async fn series_full_scan_repoints_stale_folder_ownership_to_the_scanned_folder() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let previous_root = tempfile::tempdir().expect("previous root");
+    std::fs::create_dir(previous_root.path().join("Remaining Serial"))
+        .expect("create remaining series folder");
+    let stale_folder = previous_root.path().join("Relocated Serial");
+    let candidate_folder = tempdir.path().join("Relocated Serial");
+    std::fs::create_dir(&candidate_folder).expect("create relocated series folder");
+    let episode_path = candidate_folder.join("Relocated Serial - S01E01.mkv");
+    std::fs::write(&episode_path, vec![0_u8; 128]).expect("write episode file");
+
+    let settings = Arc::new(StoredSettingsRepo::default());
+    settings
+        .set_value(
+            SETTINGS_SCOPE_MEDIA,
+            "series.path",
+            tempdir.path().to_string_lossy().as_ref(),
+        )
+        .await;
+    let unmatched_items = Arc::new(TrackingLibraryScanUnmatchedItemRepo::default());
+    let (app, user) = bootstrap_with_scan_unmatched_and_metadata_tracking(
+        settings,
+        Arc::new(MutableLibraryScanner::default()),
+        unmatched_items.clone(),
+        Arc::new(EmptySearchMetadataGateway),
+    );
+    app.reconcile_default_library_roots()
+        .await
+        .expect("reconcile series root");
+    let title = app
+        .add_title(
+            &user,
+            NewTitle {
+                name: "Relocated Serial".into(),
+                facet: MediaFacet::Series,
+                monitored: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create series title");
+    app.services
+        .catalog
+        .titles
+        .set_folder_path(&title.id, stale_folder.to_string_lossy().as_ref())
+        .await
+        .expect("set stale series folder");
+
+    let summary = app
+        .scan_library(&user, MediaFacet::Series)
+        .await
+        .expect("scan series library");
+
+    assert_eq!(summary.unmatched, 0);
+    assert!(unmatched_items.items().await.is_empty());
+    let healed = app
+        .services
+        .catalog
+        .titles
+        .get_by_id(&title.id)
+        .await
+        .expect("load title")
+        .expect("title exists");
+    assert_eq!(
+        healed.folder_path.as_deref(),
+        Some(candidate_folder.to_string_lossy().as_ref())
+    );
+    assert!(episode_path.exists());
 }
 
 #[tokio::test]

--- a/crates/scryer-application/src/library/library.rs
+++ b/crates/scryer-application/src/library/library.rs
@@ -89,6 +89,7 @@ use scan_title_files::{
 };
 use scan_title_finalize::finalize_movie_scan_file;
 pub(crate) use scan_title_finalize::finalize_title_scan_file;
+pub(crate) use scan_title_scan::{LibraryRootState, library_root_state};
 use scan_title_scan::{LibraryScanMediaAnalysisPolicy, LibraryScanMediaAnalysisPool};
 
 /// Destination for matched title work. Implemented by the media-analysis pool

--- a/crates/scryer-application/src/library/scan/candidates.rs
+++ b/crates/scryer-application/src/library/scan/candidates.rs
@@ -46,6 +46,22 @@ async fn persist_title_folder_ownership_conflict(
     Ok(item)
 }
 
+/// Heal a title whose recorded folder no longer exists by re-pointing it at
+/// the folder the scan found its files in. Returns `true` when the title now
+/// owns `scan_folder_path`; `false` leaves the ownership conflict to the
+/// caller. A title whose owned folder is still on disk, or whose owned root
+/// looks unmounted, is never touched.
+async fn reclaim_stale_title_folder_for_scan(
+    app: &AppUseCase,
+    title: &mut Title,
+    scan_folder_path: &Path,
+) -> AppResult<bool> {
+    if !crate::folder_ownership::title_folder_is_stale(title).await {
+        return Ok(false);
+    }
+    crate::folder_ownership::reclaim_stale_title_folder(app, title, scan_folder_path).await
+}
+
 async fn claim_series_candidate_folder(
     app: &AppUseCase,
     title: &mut Title,
@@ -63,7 +79,9 @@ async fn prepare_series_title_for_candidate(
     title: &mut Title,
     candidate: &PreparedSeriesLibraryScanCandidate,
 ) -> AppResult<Option<LibraryScanUnmatchedItem>> {
-    if crate::folder_ownership::title_owns_another_folder(title, &candidate.folder_path) {
+    if crate::folder_ownership::title_owns_another_folder(title, &candidate.folder_path)
+        && !reclaim_stale_title_folder_for_scan(app, title, &candidate.folder_path).await?
+    {
         crate::folder_ownership::unlink_title_media_in_folder(app, title, &candidate.folder_path)
             .await?;
         let item_path = candidate.item_path();
@@ -206,8 +224,22 @@ async fn sync_movie_title_folder_path_for_scan(
     );
     let current_folder_path = normalize_title_folder_path(title.folder_path.clone());
 
-    if current_folder_path.is_some() {
-        return Ok((current_folder_path, scan_folder_path));
+    if let Some(current_folder_path) = current_folder_path {
+        if let Some(folder_path) = scan_folder_path.as_deref()
+            && !crate::stored_paths::folder_paths_match(&current_folder_path, folder_path)
+            && reclaim_stale_title_folder_for_scan(
+                app,
+                title,
+                &stored_path_to_path_buf(folder_path),
+            )
+            .await?
+        {
+            return Ok((
+                normalize_title_folder_path(title.folder_path.clone()),
+                scan_folder_path,
+            ));
+        }
+        return Ok((Some(current_folder_path), scan_folder_path));
     }
 
     let Some(folder_path) = scan_folder_path.as_deref() else {

--- a/crates/scryer-application/src/library/scan/title_scan.rs
+++ b/crates/scryer-application/src/library/scan/title_scan.rs
@@ -110,13 +110,13 @@ async fn episodic_title_directory_present(title_dir: &Path) -> AppResult<bool> {
 /// deleted. Only a populated root makes a missing title directory a real
 /// deletion.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum LibraryRootState {
+pub(crate) enum LibraryRootState {
     Missing,
     Empty,
     Populated,
 }
 
-async fn library_root_state(root: &Path) -> AppResult<LibraryRootState> {
+pub(crate) async fn library_root_state(root: &Path) -> AppResult<LibraryRootState> {
     match tokio::fs::metadata(root).await {
         Ok(metadata) if metadata.is_dir() => {}
         Ok(_) => return Ok(LibraryRootState::Missing),

--- a/crates/scryer-application/src/library/user_delete.rs
+++ b/crates/scryer-application/src/library/user_delete.rs
@@ -228,17 +228,24 @@ impl AppUseCase {
             .into_iter()
             .map(|title| (title.title_id.clone(), title))
             .collect::<HashMap<_, _>>();
-        let requested_facets = title_ids
+        // Roots are resolved per library, not per facet: a title in a
+        // non-default library lives under that library's roots, and checking
+        // it against the facet default's roots refuses every such delete.
+        let requested_libraries = title_ids
             .iter()
-            .filter_map(|title_id| titles_by_id.get(title_id).map(|title| title.facet.clone()))
+            .filter_map(|title_id| {
+                titles_by_id
+                    .get(title_id)
+                    .map(|title| (title.library_id.clone(), title.facet.clone()))
+            })
             .collect::<HashSet<_>>();
-        let mut root_folders_by_facet = HashMap::new();
-        for facet in requested_facets {
+        let mut root_folders_by_library = HashMap::new();
+        for (library_id, facet) in requested_libraries {
             let root_folders = self
-                .root_folders_for_facet(&facet)
+                .root_folders_for_library(&library_id, &facet)
                 .await
                 .map_err(|error| error.to_string());
-            root_folders_by_facet.insert(facet, root_folders);
+            root_folders_by_library.insert(library_id, root_folders);
         }
         let tracked_title_folders = titles_by_id
             .values()
@@ -247,7 +254,7 @@ impl AppUseCase {
             .collect::<Vec<_>>();
 
         let titles_by_id = Arc::new(titles_by_id);
-        let root_folders_by_facet = Arc::new(root_folders_by_facet);
+        let root_folders_by_library = Arc::new(root_folders_by_library);
         let tracked_title_folders = Arc::new(tracked_title_folders);
 
         for chunk in title_ids.chunks(BULK_DELETE_PREVIEW_CONCURRENCY) {
@@ -257,7 +264,7 @@ impl AppUseCase {
                 let actor = actor.clone();
                 let title_id = title_id.clone();
                 let titles_by_id = Arc::clone(&titles_by_id);
-                let root_folders_by_facet = Arc::clone(&root_folders_by_facet);
+                let root_folders_by_library = Arc::clone(&root_folders_by_library);
                 let tracked_title_folders = Arc::clone(&tracked_title_folders);
                 tasks.push(tokio::spawn(async move {
                     let result = app
@@ -265,7 +272,7 @@ impl AppUseCase {
                             &actor,
                             &title_id,
                             &titles_by_id,
-                            &root_folders_by_facet,
+                            &root_folders_by_library,
                             &tracked_title_folders,
                         )
                         .await;
@@ -294,7 +301,7 @@ impl AppUseCase {
         actor: &User,
         title_id: &str,
         titles_by_id: &HashMap<String, TitleDeletePreviewInfo>,
-        root_folders_by_facet: &HashMap<MediaFacet, Result<Vec<RootFolderEntry>, String>>,
+        root_folders_by_library: &HashMap<String, Result<Vec<RootFolderEntry>, String>>,
         tracked_title_folders: &[TrackedTitleFolder],
     ) -> AppResult<DeletePreview> {
         let title = titles_by_id
@@ -307,18 +314,18 @@ impl AppUseCase {
             scryer_domain::LibraryPermission::ManageTitles,
         )
         .await?;
-        let root_folders = match root_folders_by_facet.get(&title.facet) {
+        let root_folders = match root_folders_by_library.get(&title.library_id) {
             Some(Ok(root_folders)) => root_folders.clone(),
             Some(Err(error)) => {
                 return Err(AppError::Repository(format!(
-                    "failed to load {} root folders for delete preview: {error}",
-                    title.facet.as_str()
+                    "failed to load library {} root folders for delete preview: {error}",
+                    title.library_id
                 )));
             }
             None => {
                 return Err(AppError::Repository(format!(
-                    "missing {} root folders for delete preview",
-                    title.facet.as_str()
+                    "missing library {} root folders for delete preview",
+                    title.library_id
                 )));
             }
         };
@@ -760,7 +767,9 @@ impl AppUseCase {
             .get_by_id(title_id)
             .await?
             .ok_or_else(|| AppError::NotFound(format!("title {}", title_id)))?;
-        let root_folders = self.root_folders_for_facet(&title.facet).await?;
+        let root_folders = self
+            .root_folders_for_library(&title.library_id, &title.facet)
+            .await?;
         let other_titles = self
             .services
             .catalog

--- a/crates/scryer-application/src/quality/trash_guides_release_groups.generated.rs
+++ b/crates/scryer-application/src/quality/trash_guides_release_groups.generated.rs
@@ -2,7 +2,7 @@
 // Do not edit by hand.
 
 #[allow(dead_code)]
-pub const TRASH_GUIDES_SOURCE_REVISION: &str = "31a2716d03a3f554a5a2a6bd76456109d900af05";
+pub const TRASH_GUIDES_SOURCE_REVISION: &str = "cfc3e01d5f79baf41374c75e0afface8c464c699";
 
 pub static GROUP_RULES: &[GroupRule] = &[
     GroupRule {
@@ -2883,26 +2883,6 @@ pub static GROUP_RULES: &[GroupRule] = &[
             tier: GroupTier::Banned,
             facet: RuleFacet::Anime,
             source_context: SourceContext::Anime,
-        },
-    },
-    GroupRule {
-        matcher: "HHWEB",
-        match_kind: GroupMatchKind::Exact,
-        entry: GroupEntry {
-            name: "HHWEB",
-            tier: GroupTier::Bronze,
-            facet: RuleFacet::Movie,
-            source_context: SourceContext::Web,
-        },
-    },
-    GroupRule {
-        matcher: "HHWEB",
-        match_kind: GroupMatchKind::Exact,
-        entry: GroupEntry {
-            name: "HHWEB",
-            tier: GroupTier::Bronze,
-            facet: RuleFacet::Series,
-            source_context: SourceContext::Web,
         },
     },
     GroupRule {

--- a/crates/scryer-domain/Cargo.toml
+++ b/crates/scryer-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-domain"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-infrastructure-acquisition/Cargo.toml
+++ b/crates/scryer-infrastructure-acquisition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-acquisition"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 build = "build.rs"

--- a/crates/scryer-infrastructure-configuration/Cargo.toml
+++ b/crates/scryer-infrastructure-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-configuration"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-crypto/Cargo.toml
+++ b/crates/scryer-infrastructure-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-crypto"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-datastore/Cargo.toml
+++ b/crates/scryer-infrastructure-datastore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-datastore"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 build = "build.rs"

--- a/crates/scryer-infrastructure-identity/Cargo.toml
+++ b/crates/scryer-infrastructure-identity/Cargo.toml
@@ -14,6 +14,7 @@ scryer-infrastructure-workflow = { path = "../scryer-infrastructure-workflow" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 futures-util = "0.3"
+percent-encoding = "2"
 quick-xml = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider", "http2", "gzip", "brotli", "zstd", "deflate", "stream"] }
 serde = { workspace = true }

--- a/crates/scryer-infrastructure-identity/Cargo.toml
+++ b/crates/scryer-infrastructure-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-identity"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-identity/src/emby.rs
+++ b/crates/scryer-infrastructure-identity/src/emby.rs
@@ -5,10 +5,12 @@ use reqwest::{Client, Response, StatusCode};
 use scryer_application::{
     AppError, AppResult, EmbyApiKeyExchange, EmbyApiKeyExchangeCleanup, EmbyAvatar,
     EmbyConnectAddressStatus, EmbyConnectIdentityVerification, EmbyConnectServer,
-    EmbyConnectUserType, EmbyServerIdentity, EmbyServerUser, VerifiedExternalIdentity,
+    EmbyConnectUserType, EmbyServerIdentity, EmbyServerUser, MediaServerCatalogItem,
+    MediaServerCatalogItemKind, VerifiedExternalIdentity,
 };
-use scryer_domain::ExternalAccountProvider;
+use scryer_domain::{ExternalAccountProvider, ExternalId};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use url::Url;
 
 const SCRYER_PRODUCT: &str = "Scryer";
@@ -19,6 +21,8 @@ const PAGE_LIMIT: usize = 100;
 const RECORD_LIMIT: usize = 10_000;
 const CONNECT_DISCOVERY_TIMEOUT: std::time::Duration = scryer_outbound_http::STANDARD_HTTP_TIMEOUT;
 const CONNECT_PROBE_CONCURRENCY: usize = 8;
+const CATALOG_PAGE_SIZE: usize = 500;
+const CATALOG_FIELDS: &str = "ProviderIds,SeriesId,ParentIndexNumber,IndexNumber,IndexNumberEnd";
 
 #[derive(Clone)]
 struct ConnectSession {
@@ -1515,6 +1519,172 @@ pub(super) async fn fetch_avatar(
     }))
 }
 
+/// Walk the Emby catalog with Emby's own credential path (`X-Emby-Token`
+/// plus the `Emby` client header). Jellyfin has its own scan; the two
+/// servers share no request code.
+pub(super) async fn scan_catalog(
+    client: &Client,
+    connection_id: &str,
+    base_url: &str,
+    api_key: &str,
+    recent_only: bool,
+) -> AppResult<Vec<MediaServerCatalogItem>> {
+    let base = normalized_candidate(base_url)?;
+    let api_key = api_key.trim();
+    let mut start = 0usize;
+    let mut catalog = Vec::new();
+    loop {
+        let mut url = endpoint(&base, "Items")?;
+        url.query_pairs_mut()
+            .append_pair("Recursive", "true")
+            .append_pair("IncludeItemTypes", "Movie,Series,Episode")
+            .append_pair("Fields", CATALOG_FIELDS)
+            .append_pair("StartIndex", &start.to_string())
+            .append_pair("Limit", &CATALOG_PAGE_SIZE.to_string());
+        if recent_only {
+            url.query_pairs_mut()
+                .append_pair("SortBy", "DateCreated,DateLastContentAdded")
+                .append_pair("SortOrder", "Descending");
+        }
+        let response = client
+            .get(url)
+            .header("Accept", "application/json")
+            .header("X-Emby-Token", api_key)
+            .header(
+                "X-Emby-Authorization",
+                client_authorization(connection_id, None),
+            )
+            .send()
+            .await
+            .map_err(|error| AppError::Repository(format!("Emby catalog scan failed: {error}")))?;
+        if !response.status().is_success() {
+            return Err(AppError::Repository(format!(
+                "Emby catalog scan failed with status {}",
+                response.status()
+            )));
+        }
+        let page = response.json::<Value>().await.map_err(|error| {
+            AppError::Repository(format!("invalid Emby catalog response: {error}"))
+        })?;
+        let items = page
+            .get("Items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let page_len = items.len();
+        catalog.extend(items.iter().filter_map(catalog_item));
+        start += page_len;
+        let total = page
+            .get("TotalRecordCount")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        if recent_only || page_len < CATALOG_PAGE_SIZE || (total > 0 && start >= total) {
+            return hydrate_parent_series(client, connection_id, &base, api_key, catalog).await;
+        }
+    }
+}
+
+async fn hydrate_parent_series(
+    client: &Client,
+    connection_id: &str,
+    base: &Url,
+    api_key: &str,
+    mut catalog: Vec<MediaServerCatalogItem>,
+) -> AppResult<Vec<MediaServerCatalogItem>> {
+    let mut known_series_ids = catalog
+        .iter()
+        .filter(|item| item.kind == MediaServerCatalogItemKind::Series)
+        .map(|item| item.provider_item_id.clone())
+        .collect::<HashSet<_>>();
+    let missing_series_ids = catalog
+        .iter()
+        .filter(|item| item.kind == MediaServerCatalogItemKind::Episode)
+        .filter_map(|item| item.series_provider_item_id.clone())
+        .filter(|series_id| known_series_ids.insert(series_id.clone()))
+        .collect::<Vec<_>>();
+
+    for series_id in missing_series_ids {
+        let mut url = endpoint(base, &format!("Items/{series_id}"))?;
+        url.query_pairs_mut().append_pair("Fields", CATALOG_FIELDS);
+        let response = client
+            .get(url)
+            .header("Accept", "application/json")
+            .header("X-Emby-Token", api_key)
+            .header(
+                "X-Emby-Authorization",
+                client_authorization(connection_id, None),
+            )
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::Repository(format!("Emby parent-series lookup failed: {error}"))
+            })?;
+        if response.status() == StatusCode::NOT_FOUND {
+            continue;
+        }
+        if !response.status().is_success() {
+            return Err(AppError::Repository(format!(
+                "Emby parent-series lookup failed with status {}",
+                response.status()
+            )));
+        }
+        let value = response.json::<Value>().await.map_err(|error| {
+            AppError::Repository(format!("invalid Emby parent-series response: {error}"))
+        })?;
+        if let Some(series) = catalog_item(&value)
+            && series.kind == MediaServerCatalogItemKind::Series
+        {
+            catalog.push(series);
+        }
+    }
+    Ok(catalog)
+}
+
+fn catalog_item(value: &Value) -> Option<MediaServerCatalogItem> {
+    let kind = match value.get("Type")?.as_str()? {
+        "Movie" => MediaServerCatalogItemKind::Movie,
+        "Series" => MediaServerCatalogItemKind::Series,
+        "Episode" => MediaServerCatalogItemKind::Episode,
+        _ => return None,
+    };
+    Some(MediaServerCatalogItem {
+        kind,
+        provider_item_id: value.get("Id")?.as_str()?.trim().to_string(),
+        external_ids: provider_ids(value.get("ProviderIds")),
+        series_provider_item_id: value
+            .get("SeriesId")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        season_number: value
+            .get("ParentIndexNumber")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32),
+        episode_number: value
+            .get("IndexNumber")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32),
+        episode_number_end: value
+            .get("IndexNumberEnd")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32),
+    })
+}
+
+fn provider_ids(value: Option<&Value>) -> Vec<ExternalId> {
+    let Some(Value::Object(values)) = value else {
+        return Vec::new();
+    };
+    values
+        .iter()
+        .filter_map(|(source, value)| {
+            value.as_str().map(|value| ExternalId {
+                source: source.clone(),
+                value: value.to_string(),
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1530,6 +1700,63 @@ mod tests {
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("test HTTP client")
+    }
+
+    #[tokio::test]
+    async fn catalog_scan_uses_the_emby_credential_path_only() {
+        let server = MockServer::start().await;
+        let no_media_browser_header =
+            |request: &wiremock::Request| request.headers.get("authorization").is_none();
+        // wiremock's `header` matcher splits a comma-separated value into a
+        // list, so the `Emby` client header has to be compared whole.
+        let emby_client_header = |request: &wiremock::Request| {
+            request
+                .headers
+                .get("x-emby-authorization")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value == client_authorization("emby-main", None))
+        };
+        Mock::given(method("GET"))
+            .and(path("/Items"))
+            .and(query_param("StartIndex", "0"))
+            .and(header("X-Emby-Token", "api-key"))
+            .and(emby_client_header)
+            .and(no_media_browser_header)
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Items": [
+                    {"Type": "Movie", "Id": "movie-1", "ProviderIds": {"Tmdb": "1001"}},
+                    {"Type": "Episode", "Id": "episode-1", "SeriesId": "series-1",
+                     "ParentIndexNumber": 2, "IndexNumber": 3}
+                ],
+                "TotalRecordCount": 2
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/Items/series-1"))
+            .and(header("X-Emby-Token", "api-key"))
+            .and(no_media_browser_header)
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Type": "Series", "Id": "series-1", "ProviderIds": {"Tvdb": "2002"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let catalog = scan_catalog(&test_client(), "emby-main", &server.uri(), "api-key", false)
+            .await
+            .expect("scan Emby catalog");
+
+        assert_eq!(catalog.len(), 3);
+        assert_eq!(catalog[0].kind, MediaServerCatalogItemKind::Movie);
+        assert_eq!(catalog[0].external_ids[0].source, "Tmdb");
+        assert_eq!(
+            catalog[1].series_provider_item_id.as_deref(),
+            Some("series-1")
+        );
+        assert_eq!(catalog[2].kind, MediaServerCatalogItemKind::Series);
+        assert_eq!(catalog[2].provider_item_id, "series-1");
     }
 
     async fn mount_public_info(server: &MockServer, server_id: &str) {

--- a/crates/scryer-infrastructure-identity/src/external_identity.rs
+++ b/crates/scryer-infrastructure-identity/src/external_identity.rs
@@ -68,13 +68,14 @@ impl HttpExternalIdentityVerifier {
         &self,
         keys_url: &Url,
         admin_token: &str,
+        device_id: &str,
         app_name: &str,
     ) -> AppResult<Option<String>> {
         let response = self
             .client
             .get(keys_url.clone())
             .header("Accept", "application/json")
-            .header("X-Emby-Token", admin_token)
+            .emby_family_auth(admin_token, Some(device_id))
             .send()
             .await
             .map_err(|error| {
@@ -398,7 +399,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .client
             .get(users_url)
             .header("Accept", "application/json")
-            .header("X-Emby-Token", api_key.trim())
+            .emby_family_auth(api_key.trim(), None)
             .send()
             .await
             .map_err(|error| {
@@ -424,6 +425,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
         password: &str,
     ) -> AppResult<String> {
         let base_url = jellyfin_base_url(base_url)?;
+        let device_id = media_server_device_id(connection_id);
         let auth_url = base_url.join("Users/AuthenticateByName").map_err(|error| {
             AppError::Validation(format!("Jellyfin authentication URL is invalid: {error}"))
         })?;
@@ -487,7 +489,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             AppError::Validation(format!("Jellyfin API key URL is invalid: {error}"))
         })?;
         if let Some(existing) = self
-            .find_jellyfin_api_key(&keys_url, token, SCRYER_PRODUCT)
+            .find_jellyfin_api_key(&keys_url, token, &device_id, SCRYER_PRODUCT)
             .await?
         {
             return Ok(existing);
@@ -497,7 +499,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .client
             .post(keys_url.clone())
             .header("Accept", "application/json")
-            .header("X-Emby-Token", token)
+            .emby_family_auth(token, Some(&device_id))
             .query(&[("app", SCRYER_PRODUCT)])
             .send()
             .await
@@ -511,7 +513,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             )));
         }
 
-        self.find_jellyfin_api_key(&keys_url, token, SCRYER_PRODUCT)
+        self.find_jellyfin_api_key(&keys_url, token, &device_id, SCRYER_PRODUCT)
             .await?
             .ok_or_else(|| {
                 AppError::Repository(
@@ -534,7 +536,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .client
             .get(users_url)
             .header("Accept", "application/json")
-            .header("X-Emby-Token", api_key.trim())
+            .emby_family_auth(api_key.trim(), None)
             .send()
             .await
             .map_err(|error| {
@@ -615,7 +617,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             no_redirect_reqwest_client()
                 .get(user_url)
                 .header("Accept", "application/json")
-                .header("X-Emby-Token", api_key)
+                .emby_family_auth(api_key, Some(&media_server_device_id(connection_id)))
                 .send(),
         )
         .await
@@ -1003,11 +1005,79 @@ fn jellyfin_user_avatar_url(
     Some(image_url.to_string())
 }
 
+/// The device identity Scryer presents to one media-server connection.
+///
+/// Stable per connection, so the session Jellyfin opens for a login is the
+/// same one the follow-up API-key calls are attributed to.
+fn media_server_device_id(connection_id: &str) -> String {
+    format!("SCRYER_{connection_id}")
+}
+
+/// Characters that survive a `MediaBrowser` parameter value unencoded: the
+/// URL-unreserved set. Everything else — quotes, commas, `+`, spaces — is
+/// percent-encoded, because the server unquotes each value and then runs it
+/// through `WebUtility.UrlDecode`.
+const AUTH_PARAMETER: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+fn auth_parameter(value: &str) -> String {
+    percent_encoding::utf8_percent_encode(value, AUTH_PARAMETER).to_string()
+}
+
+/// Build an `Authorization: MediaBrowser …` header value.
+///
+/// Jellyfin 12 gates every legacy credential channel it used to accept — the
+/// `X-Emby-Token`, `X-MediaBrowser-Token` and `X-Emby-Authorization` headers
+/// and the `api_key` query parameter — behind `EnableLegacyAuthorization`,
+/// which its own upgrade migration turns off (jellyfin/jellyfin#15559). This
+/// header is what remains. `Token` is its only required parameter.
+///
+/// `device_id` is omitted when the caller has no connection to bind to: an
+/// API key is not a device, and the server fills the field in from its own
+/// identity when a key arrives without one.
+fn media_browser_authorization(token: Option<&str>, device_id: Option<&str>) -> String {
+    let mut parameters = Vec::with_capacity(5);
+    if let Some(token) = token {
+        parameters.push(format!("Token=\"{}\"", auth_parameter(token)));
+    }
+    parameters.push(format!("Client=\"{}\"", auth_parameter(SCRYER_PRODUCT)));
+    parameters.push(format!("Device=\"{}\"", auth_parameter(SCRYER_PRODUCT)));
+    if let Some(device_id) = device_id {
+        parameters.push(format!("DeviceId=\"{}\"", auth_parameter(device_id)));
+    }
+    parameters.push(format!("Version=\"{}\"", auth_parameter(SCRYER_VERSION)));
+    format!("MediaBrowser {}", parameters.join(", "))
+}
+
+/// The unauthenticated header a Jellyfin login presents: it names the client
+/// and device, and carries no token because the login is what mints one.
 fn jellyfin_authorization_header(connection_id: &str) -> String {
-    let device_id = format!("SCRYER_{}", connection_id.replace('"', ""));
-    format!(
-        "MediaBrowser Client=\"{SCRYER_PRODUCT}\", Device=\"{SCRYER_PRODUCT}\", DeviceId=\"{device_id}\", Version=\"{SCRYER_VERSION}\""
-    )
+    media_browser_authorization(None, Some(&media_server_device_id(connection_id)))
+}
+
+/// Attach Scryer's credential to an Emby-family request.
+///
+/// Both channels go on every request, so one code path serves every supported
+/// server without first probing its version: Jellyfin 12 reads
+/// `Authorization` only, Jellyfin 10.x and Emby read either. Sending both is
+/// unambiguous rather than merely tolerated — the server reads the legacy
+/// header solely when `Authorization` carried no token, so the two can never
+/// disagree.
+trait EmbyFamilyAuth {
+    fn emby_family_auth(self, token: &str, device_id: Option<&str>) -> Self;
+}
+
+impl EmbyFamilyAuth for reqwest::RequestBuilder {
+    fn emby_family_auth(self, token: &str, device_id: Option<&str>) -> Self {
+        self.header(
+            "Authorization",
+            media_browser_authorization(Some(token), device_id),
+        )
+        .header("X-Emby-Token", token)
+    }
 }
 
 fn json_value_string(value: Option<&Value>) -> Option<String> {
@@ -1307,7 +1377,7 @@ async fn scan_emby_catalog(
         let response = client
             .get(url)
             .header("Accept", "application/json")
-            .header("X-Emby-Token", api_key)
+            .emby_family_auth(api_key, None)
             .send()
             .await
             .map_err(|error| {
@@ -1371,7 +1441,7 @@ async fn hydrate_emby_parent_series(
         let response = client
             .get(url)
             .header("Accept", "application/json")
-            .header("X-Emby-Token", api_key)
+            .emby_family_auth(api_key, None)
             .send()
             .await
             .map_err(|error| {
@@ -2172,6 +2242,191 @@ mod tests {
 
         assert_eq!(api_key, "generated-token");
         assert_eq!(key_list_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn media_browser_authorization_pins_the_wire_format() {
+        assert_eq!(
+            media_browser_authorization(Some("api-key"), Some("SCRYER_jellyfin-main")),
+            format!(
+                "MediaBrowser Token=\"api-key\", Client=\"Scryer\", Device=\"Scryer\", \
+                 DeviceId=\"SCRYER_jellyfin-main\", Version=\"{SCRYER_VERSION}\""
+            )
+        );
+        // A bare API key is not a device, so the parameter is left off rather
+        // than filled with a placeholder.
+        assert_eq!(
+            media_browser_authorization(Some("api-key"), None),
+            format!(
+                "MediaBrowser Token=\"api-key\", Client=\"Scryer\", Device=\"Scryer\", \
+                 Version=\"{SCRYER_VERSION}\""
+            )
+        );
+        // A login has no token yet: it is the call that mints one.
+        assert_eq!(
+            jellyfin_authorization_header("jellyfin-main"),
+            format!(
+                "MediaBrowser Client=\"Scryer\", Device=\"Scryer\", \
+                 DeviceId=\"SCRYER_jellyfin-main\", Version=\"{SCRYER_VERSION}\""
+            )
+        );
+    }
+
+    #[test]
+    fn media_browser_authorization_encodes_values_that_would_break_the_parser() {
+        // The server unquotes each value and then URL-decodes it, so a quote
+        // or comma in a pasted key must not reach the wire as a delimiter,
+        // and a `+` must not come back out as a space.
+        let header = media_browser_authorization(Some("a\"b,c d+e"), Some("SCRYER_x\"y"));
+        assert!(
+            header.contains("Token=\"a%22b%2Cc%20d%2Be\""),
+            "token was not encoded: {header}"
+        );
+        assert!(
+            header.contains("DeviceId=\"SCRYER_x%22y\""),
+            "device id was not encoded: {header}"
+        );
+    }
+
+    /// Match one exact `Authorization` value.
+    ///
+    /// wiremock's own `header` matcher reads a comma-separated value as a list
+    /// of values, so a `MediaBrowser` header never compares equal through it.
+    fn authorization(expected: String) -> impl Fn(&wiremock::Request) -> bool {
+        move |request: &wiremock::Request| {
+            request
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                == Some(expected.as_str())
+        }
+    }
+
+    /// Jellyfin 12 reads no legacy credential channel, so these mocks match on
+    /// `Authorization` alone. The sibling tests that match on `x-emby-token`
+    /// alone are the Jellyfin 10.x/Emby oracle; together they hold Scryer to
+    /// serving both server generations from one request.
+    #[tokio::test]
+    async fn jellyfin_12_user_listing_authorizes_without_the_legacy_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Users"))
+            .and(authorization(media_browser_authorization(
+                Some("api-key"),
+                None,
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "Id": "jf-user",
+                "Name": "Jelly User"
+            }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let verifier = HttpExternalIdentityVerifier::new();
+
+        let users = verifier
+            .list_jellyfin_users(&server.uri(), "api-key", None)
+            .await
+            .expect("list jellyfin users on a server that ignores X-Emby-Token");
+
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].username, "Jelly User");
+    }
+
+    #[tokio::test]
+    async fn jellyfin_12_api_key_test_authorizes_without_the_legacy_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Users"))
+            .and(authorization(media_browser_authorization(
+                Some("api-key"),
+                None,
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let verifier = HttpExternalIdentityVerifier::new();
+
+        verifier
+            .test_jellyfin_api_key(&server.uri(), "api-key")
+            .await
+            .expect("validate an api key on a server that ignores X-Emby-Token");
+    }
+
+    #[tokio::test]
+    async fn jellyfin_12_admin_exchange_authorizes_without_the_legacy_header() {
+        let server = MockServer::start().await;
+        // The key calls ride the session the login opened, so they present the
+        // same DeviceId the login did.
+        let session_auth = media_browser_authorization(Some("admin-token"), Some("SCRYER_jf-12"));
+        Mock::given(method("POST"))
+            .and(path("/Users/AuthenticateByName"))
+            .and(authorization(jellyfin_authorization_header("jf-12")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "AccessToken": "admin-token",
+                "User": {
+                    "Id": "admin-user",
+                    "Name": "Admin User",
+                    "Policy": { "IsAdministrator": true }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/Auth/Keys"))
+            .and(authorization(session_auth))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "Items": [{
+                    "AppName": "Scryer",
+                    "AccessToken": "generated-token",
+                    "DateCreated": "2026-09-11T00:00:00.0000000Z"
+                }],
+                "TotalRecordCount": 1
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let verifier = HttpExternalIdentityVerifier::new();
+
+        let api_key = verifier
+            .exchange_jellyfin_admin_api_key("jf-12", &server.uri(), "admin", "secret")
+            .await
+            .expect("exchange admin credentials on a server that ignores X-Emby-Token");
+
+        assert_eq!(api_key, "generated-token");
+    }
+
+    #[tokio::test]
+    async fn jellyfin_12_user_verification_authorizes_without_the_legacy_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Users/2c1b0a3d4e5f60718293a4b5c6d7e8f9"))
+            .and(authorization(media_browser_authorization(
+                Some("api-key"),
+                Some("SCRYER_jf-12"),
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "Id": "2c1b0a3d4e5f60718293a4b5c6d7e8f9",
+                "Name": "Jelly User"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let verifier = HttpExternalIdentityVerifier::new();
+
+        let identity = verifier
+            .verify_jellyfin_user_with_api_key(
+                "jf-12",
+                &server.uri(),
+                "api-key",
+                "2c1b0a3d4e5f60718293a4b5c6d7e8f9",
+            )
+            .await
+            .expect("verify a user on a server that ignores X-Emby-Token");
+
+        assert_eq!(identity.username, "Jelly User");
     }
 
     #[tokio::test]

--- a/crates/scryer-infrastructure-identity/src/external_identity.rs
+++ b/crates/scryer-infrastructure-identity/src/external_identity.rs
@@ -16,13 +16,14 @@ use scryer_domain::{
     ExternalAccountProvider, ExternalId, MediaServerConnection, MediaServerProvider,
 };
 use scryer_outbound_http::{generic_reqwest_client, no_redirect_reqwest_client};
+
+use crate::jellyfin::{self, JellyfinAuth};
 use serde::Deserialize;
 use serde_json::Value;
 use url::Url;
 
 const PLEX_BASE_URL: &str = "https://plex.tv";
 const SCRYER_PRODUCT: &str = "Scryer";
-const SCRYER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub struct HttpExternalIdentityVerifier {
     client: reqwest::Client,
@@ -75,7 +76,7 @@ impl HttpExternalIdentityVerifier {
             .client
             .get(keys_url.clone())
             .header("Accept", "application/json")
-            .emby_family_auth(admin_token, Some(device_id))
+            .jellyfin_auth(admin_token, Some(device_id))
             .send()
             .await
             .map_err(|error| {
@@ -284,7 +285,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .post(auth_url)
             .header(
                 "Authorization",
-                jellyfin_authorization_header(connection_id),
+                jellyfin::login_authorization(connection_id),
             )
             .header("Accept", "application/json")
             .json(&JellyfinAuthRequest { username, password })
@@ -399,7 +400,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .client
             .get(users_url)
             .header("Accept", "application/json")
-            .emby_family_auth(api_key.trim(), None)
+            .jellyfin_auth(api_key.trim(), None)
             .send()
             .await
             .map_err(|error| {
@@ -425,7 +426,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
         password: &str,
     ) -> AppResult<String> {
         let base_url = jellyfin_base_url(base_url)?;
-        let device_id = media_server_device_id(connection_id);
+        let device_id = jellyfin::device_id(connection_id);
         let auth_url = base_url.join("Users/AuthenticateByName").map_err(|error| {
             AppError::Validation(format!("Jellyfin authentication URL is invalid: {error}"))
         })?;
@@ -434,7 +435,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .post(auth_url)
             .header(
                 "Authorization",
-                jellyfin_authorization_header(connection_id),
+                jellyfin::login_authorization(connection_id),
             )
             .header("Accept", "application/json")
             .json(&JellyfinAuthRequest { username, password })
@@ -499,7 +500,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .client
             .post(keys_url.clone())
             .header("Accept", "application/json")
-            .emby_family_auth(token, Some(&device_id))
+            .jellyfin_auth(token, Some(&device_id))
             .query(&[("app", SCRYER_PRODUCT)])
             .send()
             .await
@@ -536,7 +537,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             .client
             .get(users_url)
             .header("Accept", "application/json")
-            .emby_family_auth(api_key.trim(), None)
+            .jellyfin_auth(api_key.trim(), None)
             .send()
             .await
             .map_err(|error| {
@@ -617,7 +618,7 @@ impl ExternalIdentityVerifier for HttpExternalIdentityVerifier {
             no_redirect_reqwest_client()
                 .get(user_url)
                 .header("Accept", "application/json")
-                .emby_family_auth(api_key, Some(&media_server_device_id(connection_id)))
+                .jellyfin_auth(api_key, Some(&jellyfin::device_id(connection_id)))
                 .send(),
         )
         .await
@@ -1005,81 +1006,6 @@ fn jellyfin_user_avatar_url(
     Some(image_url.to_string())
 }
 
-/// The device identity Scryer presents to one media-server connection.
-///
-/// Stable per connection, so the session Jellyfin opens for a login is the
-/// same one the follow-up API-key calls are attributed to.
-fn media_server_device_id(connection_id: &str) -> String {
-    format!("SCRYER_{connection_id}")
-}
-
-/// Characters that survive a `MediaBrowser` parameter value unencoded: the
-/// URL-unreserved set. Everything else — quotes, commas, `+`, spaces — is
-/// percent-encoded, because the server unquotes each value and then runs it
-/// through `WebUtility.UrlDecode`.
-const AUTH_PARAMETER: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'_')
-    .remove(b'.')
-    .remove(b'~');
-
-fn auth_parameter(value: &str) -> String {
-    percent_encoding::utf8_percent_encode(value, AUTH_PARAMETER).to_string()
-}
-
-/// Build an `Authorization: MediaBrowser …` header value.
-///
-/// Jellyfin 12 gates every legacy credential channel it used to accept — the
-/// `X-Emby-Token`, `X-MediaBrowser-Token` and `X-Emby-Authorization` headers
-/// and the `api_key` query parameter — behind `EnableLegacyAuthorization`,
-/// which its own upgrade migration turns off (jellyfin/jellyfin#15559). This
-/// header is what remains. `Token` is its only required parameter.
-///
-/// `device_id` is omitted when the caller has no connection to bind to: an
-/// API key is not a device, and the server fills the field in from its own
-/// identity when a key arrives without one.
-fn media_browser_authorization(token: Option<&str>, device_id: Option<&str>) -> String {
-    let mut parameters = Vec::with_capacity(5);
-    if let Some(token) = token {
-        parameters.push(format!("Token=\"{}\"", auth_parameter(token)));
-    }
-    parameters.push(format!("Client=\"{}\"", auth_parameter(SCRYER_PRODUCT)));
-    parameters.push(format!("Device=\"{}\"", auth_parameter(SCRYER_PRODUCT)));
-    if let Some(device_id) = device_id {
-        parameters.push(format!("DeviceId=\"{}\"", auth_parameter(device_id)));
-    }
-    parameters.push(format!("Version=\"{}\"", auth_parameter(SCRYER_VERSION)));
-    format!("MediaBrowser {}", parameters.join(", "))
-}
-
-/// The unauthenticated header a Jellyfin login presents: it names the client
-/// and device, and carries no token because the login is what mints one.
-fn jellyfin_authorization_header(connection_id: &str) -> String {
-    media_browser_authorization(None, Some(&media_server_device_id(connection_id)))
-}
-
-/// Attach Scryer's credential to an Emby-family request.
-///
-/// Both channels go on every request, so one code path serves every supported
-/// server without first probing its version: Jellyfin 12 reads
-/// `Authorization` only, Jellyfin 10.x and Emby read either. Sending both is
-/// unambiguous rather than merely tolerated — the server reads the legacy
-/// header solely when `Authorization` carried no token, so the two can never
-/// disagree.
-trait EmbyFamilyAuth {
-    fn emby_family_auth(self, token: &str, device_id: Option<&str>) -> Self;
-}
-
-impl EmbyFamilyAuth for reqwest::RequestBuilder {
-    fn emby_family_auth(self, token: &str, device_id: Option<&str>) -> Self {
-        self.header(
-            "Authorization",
-            media_browser_authorization(Some(token), device_id),
-        )
-        .header("X-Emby-Token", token)
-    }
-}
-
 fn json_value_string(value: Option<&Value>) -> Option<String> {
     match value? {
         Value::String(value) => {
@@ -1329,8 +1255,19 @@ async fn scan_media_server_catalog(
             AppError::Validation("media server catalog scan requires an API key".into())
         })?;
     match connection.provider {
-        MediaServerProvider::Jellyfin | MediaServerProvider::Emby => {
-            scan_emby_catalog(&verifier.client, &connection.base_url, api_key, recent_only).await
+        MediaServerProvider::Jellyfin => {
+            jellyfin::scan_catalog(&verifier.client, &connection.base_url, api_key, recent_only)
+                .await
+        }
+        MediaServerProvider::Emby => {
+            super::emby::scan_catalog(
+                &verifier.client,
+                &connection.id,
+                &connection.base_url,
+                api_key,
+                recent_only,
+            )
+            .await
         }
         MediaServerProvider::Plex => {
             let machine_id = connection
@@ -1344,160 +1281,6 @@ async fn scan_media_server_catalog(
             scan_plex_catalog(verifier, machine_id, api_key, recent_only).await
         }
     }
-}
-
-async fn scan_emby_catalog(
-    client: &reqwest::Client,
-    base_url: &str,
-    api_key: &str,
-    recent_only: bool,
-) -> AppResult<Vec<MediaServerCatalogItem>> {
-    let base_url = media_server_url(base_url)?;
-    let mut start = 0usize;
-    let mut catalog = Vec::new();
-    const PAGE_SIZE: usize = 500;
-    loop {
-        let mut url = base_url.join("Items").map_err(|error| {
-            AppError::Repository(format!("invalid media server catalog URL: {error}"))
-        })?;
-        url.query_pairs_mut()
-            .append_pair("Recursive", "true")
-            .append_pair("IncludeItemTypes", "Movie,Series,Episode")
-            .append_pair(
-                "Fields",
-                "ProviderIds,SeriesId,ParentIndexNumber,IndexNumber,IndexNumberEnd",
-            )
-            .append_pair("StartIndex", &start.to_string())
-            .append_pair("Limit", &PAGE_SIZE.to_string());
-        if recent_only {
-            url.query_pairs_mut()
-                .append_pair("SortBy", "DateCreated,DateLastContentAdded")
-                .append_pair("SortOrder", "Descending");
-        }
-        let response = client
-            .get(url)
-            .header("Accept", "application/json")
-            .emby_family_auth(api_key, None)
-            .send()
-            .await
-            .map_err(|error| {
-                AppError::Repository(format!("media server catalog scan failed: {error}"))
-            })?;
-        if !response.status().is_success() {
-            return Err(AppError::Repository(format!(
-                "media server catalog scan failed with status {}",
-                response.status()
-            )));
-        }
-        let page = response.json::<Value>().await.map_err(|error| {
-            AppError::Repository(format!("invalid media server catalog response: {error}"))
-        })?;
-        let items = page
-            .get("Items")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        let page_len = items.len();
-        catalog.extend(items.iter().filter_map(emby_catalog_item));
-        start += page_len;
-        let total = page
-            .get("TotalRecordCount")
-            .and_then(Value::as_u64)
-            .unwrap_or(0) as usize;
-        if recent_only || page_len < PAGE_SIZE || (total > 0 && start >= total) {
-            return hydrate_emby_parent_series(client, &base_url, api_key, catalog).await;
-        }
-    }
-}
-
-async fn hydrate_emby_parent_series(
-    client: &reqwest::Client,
-    base_url: &Url,
-    api_key: &str,
-    mut catalog: Vec<MediaServerCatalogItem>,
-) -> AppResult<Vec<MediaServerCatalogItem>> {
-    let mut known_series_ids = catalog
-        .iter()
-        .filter(|item| item.kind == MediaServerCatalogItemKind::Series)
-        .map(|item| item.provider_item_id.clone())
-        .collect::<HashSet<_>>();
-    let missing_series_ids = catalog
-        .iter()
-        .filter(|item| item.kind == MediaServerCatalogItemKind::Episode)
-        .filter_map(|item| item.series_provider_item_id.clone())
-        .filter(|series_id| known_series_ids.insert(series_id.clone()))
-        .collect::<Vec<_>>();
-
-    for series_id in missing_series_ids {
-        let mut url = base_url
-            .join(&format!("Items/{series_id}"))
-            .map_err(|error| {
-                AppError::Repository(format!("invalid media server catalog URL: {error}"))
-            })?;
-        url.query_pairs_mut().append_pair(
-            "Fields",
-            "ProviderIds,SeriesId,ParentIndexNumber,IndexNumber,IndexNumberEnd",
-        );
-        let response = client
-            .get(url)
-            .header("Accept", "application/json")
-            .emby_family_auth(api_key, None)
-            .send()
-            .await
-            .map_err(|error| {
-                AppError::Repository(format!("media server parent-series lookup failed: {error}"))
-            })?;
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
-            continue;
-        }
-        if !response.status().is_success() {
-            return Err(AppError::Repository(format!(
-                "media server parent-series lookup failed with status {}",
-                response.status()
-            )));
-        }
-        let value = response.json::<Value>().await.map_err(|error| {
-            AppError::Repository(format!(
-                "invalid media server parent-series response: {error}"
-            ))
-        })?;
-        if let Some(series) = emby_catalog_item(&value)
-            && series.kind == MediaServerCatalogItemKind::Series
-        {
-            catalog.push(series);
-        }
-    }
-    Ok(catalog)
-}
-
-fn emby_catalog_item(value: &Value) -> Option<MediaServerCatalogItem> {
-    let kind = match value.get("Type")?.as_str()? {
-        "Movie" => MediaServerCatalogItemKind::Movie,
-        "Series" => MediaServerCatalogItemKind::Series,
-        "Episode" => MediaServerCatalogItemKind::Episode,
-        _ => return None,
-    };
-    Some(MediaServerCatalogItem {
-        kind,
-        provider_item_id: value.get("Id")?.as_str()?.trim().to_string(),
-        external_ids: provider_ids(value.get("ProviderIds")),
-        series_provider_item_id: value
-            .get("SeriesId")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        season_number: value
-            .get("ParentIndexNumber")
-            .and_then(Value::as_i64)
-            .map(|value| value as i32),
-        episode_number: value
-            .get("IndexNumber")
-            .and_then(Value::as_i64)
-            .map(|value| value as i32),
-        episode_number_end: value
-            .get("IndexNumberEnd")
-            .and_then(Value::as_i64)
-            .map(|value| value as i32),
-    })
 }
 
 async fn scan_plex_catalog(
@@ -1781,34 +1564,6 @@ fn plex_external_id(value: &str) -> Option<ExternalId> {
         source: source.into(),
         value: external_id.into(),
     })
-}
-
-fn provider_ids(value: Option<&Value>) -> Vec<ExternalId> {
-    let Some(value) = value else {
-        return Vec::new();
-    };
-    match value {
-        Value::Object(values) => values
-            .iter()
-            .filter_map(|(source, value)| {
-                value.as_str().map(|value| ExternalId {
-                    source: source.clone(),
-                    value: value.to_string(),
-                })
-            })
-            .collect(),
-        Value::Array(values) => values
-            .iter()
-            .filter_map(|value| value.get("id").and_then(Value::as_str))
-            .filter_map(|value| {
-                value.split_once("://").map(|(source, id)| ExternalId {
-                    source: source.into(),
-                    value: id.into(),
-                })
-            })
-            .collect(),
-        _ => Vec::new(),
-    }
 }
 
 fn media_server_url(value: &str) -> AppResult<Url> {
@@ -2244,50 +1999,6 @@ mod tests {
         assert_eq!(key_list_calls.load(Ordering::SeqCst), 2);
     }
 
-    #[test]
-    fn media_browser_authorization_pins_the_wire_format() {
-        assert_eq!(
-            media_browser_authorization(Some("api-key"), Some("SCRYER_jellyfin-main")),
-            format!(
-                "MediaBrowser Token=\"api-key\", Client=\"Scryer\", Device=\"Scryer\", \
-                 DeviceId=\"SCRYER_jellyfin-main\", Version=\"{SCRYER_VERSION}\""
-            )
-        );
-        // A bare API key is not a device, so the parameter is left off rather
-        // than filled with a placeholder.
-        assert_eq!(
-            media_browser_authorization(Some("api-key"), None),
-            format!(
-                "MediaBrowser Token=\"api-key\", Client=\"Scryer\", Device=\"Scryer\", \
-                 Version=\"{SCRYER_VERSION}\""
-            )
-        );
-        // A login has no token yet: it is the call that mints one.
-        assert_eq!(
-            jellyfin_authorization_header("jellyfin-main"),
-            format!(
-                "MediaBrowser Client=\"Scryer\", Device=\"Scryer\", \
-                 DeviceId=\"SCRYER_jellyfin-main\", Version=\"{SCRYER_VERSION}\""
-            )
-        );
-    }
-
-    #[test]
-    fn media_browser_authorization_encodes_values_that_would_break_the_parser() {
-        // The server unquotes each value and then URL-decodes it, so a quote
-        // or comma in a pasted key must not reach the wire as a delimiter,
-        // and a `+` must not come back out as a space.
-        let header = media_browser_authorization(Some("a\"b,c d+e"), Some("SCRYER_x\"y"));
-        assert!(
-            header.contains("Token=\"a%22b%2Cc%20d%2Be\""),
-            "token was not encoded: {header}"
-        );
-        assert!(
-            header.contains("DeviceId=\"SCRYER_x%22y\""),
-            "device id was not encoded: {header}"
-        );
-    }
-
     /// Match one exact `Authorization` value.
     ///
     /// wiremock's own `header` matcher reads a comma-separated value as a list
@@ -2311,7 +2022,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/Users"))
-            .and(authorization(media_browser_authorization(
+            .and(authorization(jellyfin::authorization(
                 Some("api-key"),
                 None,
             )))
@@ -2338,7 +2049,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/Users"))
-            .and(authorization(media_browser_authorization(
+            .and(authorization(jellyfin::authorization(
                 Some("api-key"),
                 None,
             )))
@@ -2359,10 +2070,10 @@ mod tests {
         let server = MockServer::start().await;
         // The key calls ride the session the login opened, so they present the
         // same DeviceId the login did.
-        let session_auth = media_browser_authorization(Some("admin-token"), Some("SCRYER_jf-12"));
+        let session_auth = jellyfin::authorization(Some("admin-token"), Some("SCRYER_jf-12"));
         Mock::given(method("POST"))
             .and(path("/Users/AuthenticateByName"))
-            .and(authorization(jellyfin_authorization_header("jf-12")))
+            .and(authorization(jellyfin::login_authorization("jf-12")))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "AccessToken": "admin-token",
                 "User": {
@@ -2403,7 +2114,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/Users/2c1b0a3d4e5f60718293a4b5c6d7e8f9"))
-            .and(authorization(media_browser_authorization(
+            .and(authorization(jellyfin::authorization(
                 Some("api-key"),
                 Some("SCRYER_jf-12"),
             )))

--- a/crates/scryer-infrastructure-identity/src/jellyfin.rs
+++ b/crates/scryer-infrastructure-identity/src/jellyfin.rs
@@ -1,0 +1,379 @@
+//! Jellyfin wire details: the `MediaBrowser` authorization scheme and the
+//! catalog scan. Emby has its own module; the two servers share no request
+//! path so a change to one server's protocol never reaches the other.
+
+use std::collections::HashSet;
+
+use reqwest::Client;
+use scryer_application::{AppError, AppResult, MediaServerCatalogItem, MediaServerCatalogItemKind};
+use scryer_domain::ExternalId;
+use serde_json::Value;
+use url::Url;
+
+const SCRYER_PRODUCT: &str = "Scryer";
+const SCRYER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const CATALOG_PAGE_SIZE: usize = 500;
+const CATALOG_FIELDS: &str = "ProviderIds,SeriesId,ParentIndexNumber,IndexNumber,IndexNumberEnd";
+
+/// The device identity Scryer presents to one Jellyfin connection.
+///
+/// Stable per connection, so the session Jellyfin opens for a login is the
+/// same one the follow-up API-key calls are attributed to.
+pub(super) fn device_id(connection_id: &str) -> String {
+    format!("SCRYER_{connection_id}")
+}
+
+/// Characters that survive a `MediaBrowser` parameter value unencoded: the
+/// URL-unreserved set. Everything else — quotes, commas, `+`, spaces — is
+/// percent-encoded, because the server unquotes each value and then runs it
+/// through `WebUtility.UrlDecode`.
+const AUTH_PARAMETER: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+fn auth_parameter(value: &str) -> String {
+    percent_encoding::utf8_percent_encode(value, AUTH_PARAMETER).to_string()
+}
+
+/// Build an `Authorization: MediaBrowser …` header value.
+///
+/// Jellyfin 12 gates every legacy credential channel it used to accept — the
+/// `X-Emby-Token`, `X-MediaBrowser-Token` and `X-Emby-Authorization` headers
+/// and the `api_key` query parameter — behind `EnableLegacyAuthorization`,
+/// which its own upgrade migration turns off (jellyfin/jellyfin#15559). This
+/// header is what remains. `Token` is its only required parameter.
+///
+/// `device_id` is omitted when the caller has no connection to bind to: an
+/// API key is not a device, and the server fills the field in from its own
+/// identity when a key arrives without one.
+pub(super) fn authorization(token: Option<&str>, device_id: Option<&str>) -> String {
+    let mut parameters = Vec::with_capacity(5);
+    if let Some(token) = token {
+        parameters.push(format!("Token=\"{}\"", auth_parameter(token)));
+    }
+    parameters.push(format!("Client=\"{}\"", auth_parameter(SCRYER_PRODUCT)));
+    parameters.push(format!("Device=\"{}\"", auth_parameter(SCRYER_PRODUCT)));
+    if let Some(device_id) = device_id {
+        parameters.push(format!("DeviceId=\"{}\"", auth_parameter(device_id)));
+    }
+    parameters.push(format!("Version=\"{}\"", auth_parameter(SCRYER_VERSION)));
+    format!("MediaBrowser {}", parameters.join(", "))
+}
+
+/// The unauthenticated header a Jellyfin login presents: it names the client
+/// and device, and carries no token because the login is what mints one.
+pub(super) fn login_authorization(connection_id: &str) -> String {
+    authorization(None, Some(&device_id(connection_id)))
+}
+
+/// Attach Scryer's credential to a Jellyfin request.
+///
+/// Both channels go on every request, so one code path serves every Jellyfin
+/// generation without first probing its version: Jellyfin 12 reads
+/// `Authorization` only, Jellyfin 10.x reads either. Sending both is
+/// unambiguous rather than merely tolerated — the server reads the legacy
+/// header solely when `Authorization` carried no token, so the two can never
+/// disagree.
+pub(super) trait JellyfinAuth {
+    fn jellyfin_auth(self, token: &str, device_id: Option<&str>) -> Self;
+}
+
+impl JellyfinAuth for reqwest::RequestBuilder {
+    fn jellyfin_auth(self, token: &str, device_id: Option<&str>) -> Self {
+        self.header("Authorization", authorization(Some(token), device_id))
+            .header("X-Emby-Token", token)
+    }
+}
+
+fn base_url(value: &str) -> AppResult<Url> {
+    let mut url = Url::parse(value.trim())
+        .map_err(|error| AppError::Repository(format!("invalid Jellyfin URL: {error}")))?;
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+    Ok(url)
+}
+
+fn catalog_url(base_url: &Url, path: &str) -> AppResult<Url> {
+    base_url
+        .join(path)
+        .map_err(|error| AppError::Repository(format!("invalid Jellyfin catalog URL: {error}")))
+}
+
+pub(super) async fn scan_catalog(
+    client: &Client,
+    base_url: &str,
+    api_key: &str,
+    recent_only: bool,
+) -> AppResult<Vec<MediaServerCatalogItem>> {
+    let base_url = self::base_url(base_url)?;
+    let mut start = 0usize;
+    let mut catalog = Vec::new();
+    loop {
+        let mut url = catalog_url(&base_url, "Items")?;
+        url.query_pairs_mut()
+            .append_pair("Recursive", "true")
+            .append_pair("IncludeItemTypes", "Movie,Series,Episode")
+            .append_pair("Fields", CATALOG_FIELDS)
+            .append_pair("StartIndex", &start.to_string())
+            .append_pair("Limit", &CATALOG_PAGE_SIZE.to_string());
+        if recent_only {
+            url.query_pairs_mut()
+                .append_pair("SortBy", "DateCreated,DateLastContentAdded")
+                .append_pair("SortOrder", "Descending");
+        }
+        let response = client
+            .get(url)
+            .header("Accept", "application/json")
+            .jellyfin_auth(api_key, None)
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::Repository(format!("Jellyfin catalog scan failed: {error}"))
+            })?;
+        if !response.status().is_success() {
+            return Err(AppError::Repository(format!(
+                "Jellyfin catalog scan failed with status {}",
+                response.status()
+            )));
+        }
+        let page = response.json::<Value>().await.map_err(|error| {
+            AppError::Repository(format!("invalid Jellyfin catalog response: {error}"))
+        })?;
+        let items = page
+            .get("Items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let page_len = items.len();
+        catalog.extend(items.iter().filter_map(catalog_item));
+        start += page_len;
+        let total = page
+            .get("TotalRecordCount")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        if recent_only || page_len < CATALOG_PAGE_SIZE || (total > 0 && start >= total) {
+            return hydrate_parent_series(client, &base_url, api_key, catalog).await;
+        }
+    }
+}
+
+async fn hydrate_parent_series(
+    client: &Client,
+    base_url: &Url,
+    api_key: &str,
+    mut catalog: Vec<MediaServerCatalogItem>,
+) -> AppResult<Vec<MediaServerCatalogItem>> {
+    let mut known_series_ids = catalog
+        .iter()
+        .filter(|item| item.kind == MediaServerCatalogItemKind::Series)
+        .map(|item| item.provider_item_id.clone())
+        .collect::<HashSet<_>>();
+    let missing_series_ids = catalog
+        .iter()
+        .filter(|item| item.kind == MediaServerCatalogItemKind::Episode)
+        .filter_map(|item| item.series_provider_item_id.clone())
+        .filter(|series_id| known_series_ids.insert(series_id.clone()))
+        .collect::<Vec<_>>();
+
+    for series_id in missing_series_ids {
+        let mut url = catalog_url(base_url, &format!("Items/{series_id}"))?;
+        url.query_pairs_mut().append_pair("Fields", CATALOG_FIELDS);
+        let response = client
+            .get(url)
+            .header("Accept", "application/json")
+            .jellyfin_auth(api_key, None)
+            .send()
+            .await
+            .map_err(|error| {
+                AppError::Repository(format!("Jellyfin parent-series lookup failed: {error}"))
+            })?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            continue;
+        }
+        if !response.status().is_success() {
+            return Err(AppError::Repository(format!(
+                "Jellyfin parent-series lookup failed with status {}",
+                response.status()
+            )));
+        }
+        let value = response.json::<Value>().await.map_err(|error| {
+            AppError::Repository(format!("invalid Jellyfin parent-series response: {error}"))
+        })?;
+        if let Some(series) = catalog_item(&value)
+            && series.kind == MediaServerCatalogItemKind::Series
+        {
+            catalog.push(series);
+        }
+    }
+    Ok(catalog)
+}
+
+fn catalog_item(value: &Value) -> Option<MediaServerCatalogItem> {
+    let kind = match value.get("Type")?.as_str()? {
+        "Movie" => MediaServerCatalogItemKind::Movie,
+        "Series" => MediaServerCatalogItemKind::Series,
+        "Episode" => MediaServerCatalogItemKind::Episode,
+        _ => return None,
+    };
+    Some(MediaServerCatalogItem {
+        kind,
+        provider_item_id: value.get("Id")?.as_str()?.trim().to_string(),
+        external_ids: provider_ids(value.get("ProviderIds")),
+        series_provider_item_id: value
+            .get("SeriesId")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        season_number: value
+            .get("ParentIndexNumber")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32),
+        episode_number: value
+            .get("IndexNumber")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32),
+        episode_number_end: value
+            .get("IndexNumberEnd")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32),
+    })
+}
+
+fn provider_ids(value: Option<&Value>) -> Vec<ExternalId> {
+    let Some(Value::Object(values)) = value else {
+        return Vec::new();
+    };
+    values
+        .iter()
+        .filter_map(|(source, value)| {
+            value.as_str().map(|value| ExternalId {
+                source: source.clone(),
+                value: value.to_string(),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn test_client() -> Client {
+        scryer_outbound_http::install_default_rustls_provider();
+        Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("test HTTP client")
+    }
+
+    /// Match one exact `Authorization` value.
+    ///
+    /// wiremock's own `header` matcher reads a comma-separated value as a list
+    /// of values, so a `MediaBrowser` header never compares equal through it.
+    fn authorization_header(expected: String) -> impl Fn(&wiremock::Request) -> bool {
+        move |request: &wiremock::Request| {
+            request
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value == expected)
+        }
+    }
+
+    #[test]
+    fn authorization_pins_the_wire_format() {
+        assert_eq!(
+            authorization(Some("api-key"), Some("SCRYER_jellyfin-main")),
+            format!(
+                "MediaBrowser Token=\"api-key\", Client=\"Scryer\", Device=\"Scryer\", \
+                 DeviceId=\"SCRYER_jellyfin-main\", Version=\"{SCRYER_VERSION}\""
+            )
+        );
+        // A bare API key is not a device, so the parameter is left off rather
+        // than filled with a placeholder.
+        assert_eq!(
+            authorization(Some("api-key"), None),
+            format!(
+                "MediaBrowser Token=\"api-key\", Client=\"Scryer\", Device=\"Scryer\", \
+                 Version=\"{SCRYER_VERSION}\""
+            )
+        );
+        // A login has no token yet: it is the call that mints one.
+        assert_eq!(
+            login_authorization("jellyfin-main"),
+            format!(
+                "MediaBrowser Client=\"Scryer\", Device=\"Scryer\", \
+                 DeviceId=\"SCRYER_jellyfin-main\", Version=\"{SCRYER_VERSION}\""
+            )
+        );
+    }
+
+    #[test]
+    fn authorization_encodes_values_that_would_break_the_parser() {
+        // The server unquotes each value and then URL-decodes it, so a quote
+        // or comma in a pasted key must not reach the wire as a delimiter,
+        // and a `+` must not come back out as a space.
+        let header = authorization(Some("a\"b,c d+e"), Some("SCRYER_x\"y"));
+        assert!(
+            header.contains("Token=\"a%22b%2Cc%20d%2Be\""),
+            "token was not encoded: {header}"
+        );
+        assert!(
+            header.contains("DeviceId=\"SCRYER_x%22y\""),
+            "device id was not encoded: {header}"
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_scan_authorizes_with_the_media_browser_header_and_hydrates_series() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Items"))
+            .and(query_param("StartIndex", "0"))
+            .and(authorization_header(authorization(Some("api-key"), None)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "Items": [
+                    {"Type": "Movie", "Id": "movie-1", "ProviderIds": {"Tmdb": "1001"}},
+                    {"Type": "Episode", "Id": "episode-1", "SeriesId": "series-1",
+                     "ParentIndexNumber": 2, "IndexNumber": 3, "IndexNumberEnd": 4}
+                ],
+                "TotalRecordCount": 2
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/Items/series-1"))
+            .and(authorization_header(authorization(Some("api-key"), None)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "Type": "Series", "Id": "series-1", "ProviderIds": {"Tvdb": "2002"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let catalog = scan_catalog(&test_client(), &server.uri(), "api-key", false)
+            .await
+            .expect("scan Jellyfin catalog");
+
+        assert_eq!(catalog.len(), 3);
+        assert_eq!(catalog[0].kind, MediaServerCatalogItemKind::Movie);
+        assert_eq!(catalog[0].external_ids[0].source, "Tmdb");
+        assert_eq!(catalog[1].kind, MediaServerCatalogItemKind::Episode);
+        assert_eq!(
+            catalog[1].series_provider_item_id.as_deref(),
+            Some("series-1")
+        );
+        assert_eq!(catalog[1].season_number, Some(2));
+        assert_eq!(catalog[1].episode_number, Some(3));
+        assert_eq!(catalog[1].episode_number_end, Some(4));
+        assert_eq!(catalog[2].kind, MediaServerCatalogItemKind::Series);
+        assert_eq!(catalog[2].provider_item_id, "series-1");
+    }
+}

--- a/crates/scryer-infrastructure-identity/src/lib.rs
+++ b/crates/scryer-infrastructure-identity/src/lib.rs
@@ -1,5 +1,6 @@
 mod emby;
 pub mod external_identity;
+mod jellyfin;
 pub mod oauth;
 pub mod users;
 

--- a/crates/scryer-infrastructure-library-search/Cargo.toml
+++ b/crates/scryer-infrastructure-library-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-library-search"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-library/Cargo.toml
+++ b/crates/scryer-infrastructure-library/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-library"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-metadata/Cargo.toml
+++ b/crates/scryer-infrastructure-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-metadata"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 build = "build.rs"

--- a/crates/scryer-infrastructure-notifications/Cargo.toml
+++ b/crates/scryer-infrastructure-notifications/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-notifications"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-runtime/Cargo.toml
+++ b/crates/scryer-infrastructure-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-runtime"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-sql/Cargo.toml
+++ b/crates/scryer-infrastructure-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-sql"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-infrastructure-workflow/Cargo.toml
+++ b/crates/scryer-infrastructure-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-infrastructure-workflow"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish = false
 

--- a/crates/scryer-interface-acquisition/Cargo.toml
+++ b/crates/scryer-interface-acquisition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-acquisition"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-core/Cargo.toml
+++ b/crates/scryer-interface-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-core"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-import/Cargo.toml
+++ b/crates/scryer-interface-import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-import"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-media-types/Cargo.toml
+++ b/crates/scryer-interface-media-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-media-types"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-media/Cargo.toml
+++ b/crates/scryer-interface-media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-media"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-metadata/Cargo.toml
+++ b/crates/scryer-interface-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-metadata"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-query/Cargo.toml
+++ b/crates/scryer-interface-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-query"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-security/Cargo.toml
+++ b/crates/scryer-interface-security/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-security"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-settings/Cargo.toml
+++ b/crates/scryer-interface-settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-settings"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-subscription/Cargo.toml
+++ b/crates/scryer-interface-subscription/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-subscription"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface-system/Cargo.toml
+++ b/crates/scryer-interface-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface-system"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-interface/Cargo.toml
+++ b/crates/scryer-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-interface"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-launcher/Cargo.toml
+++ b/crates/scryer-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-launcher"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-logging/Cargo.toml
+++ b/crates/scryer-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-logging"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-mediainfo/Cargo.toml
+++ b/crates/scryer-mediainfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-mediainfo"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-mock-apis/Cargo.toml
+++ b/crates/scryer-mock-apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-mock-apis"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [[bin]]

--- a/crates/scryer-outbound-http/Cargo.toml
+++ b/crates/scryer-outbound-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-outbound-http"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-plugins/Cargo.toml
+++ b/crates/scryer-plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-plugins"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-release-parser/Cargo.toml
+++ b/crates/scryer-release-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-release-parser"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-release-parser/fuzz/Cargo.lock
+++ b/crates/scryer-release-parser/fuzz/Cargo.lock
@@ -255,7 +255,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scryer-release-parser"
-version = "0.19.15"
+version = "0.19.16"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -318,9 +318,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 dependencies = [
  "serde",
 ]

--- a/crates/scryer-release-parser/src/trash_guides_parser_knowledge.generated.rs
+++ b/crates/scryer-release-parser/src/trash_guides_parser_knowledge.generated.rs
@@ -2,7 +2,7 @@
 // Do not edit by hand.
 
 #[allow(dead_code)]
-pub const TRASH_GUIDES_SOURCE_REVISION: &str = "31a2716d03a3f554a5a2a6bd76456109d900af05";
+pub const TRASH_GUIDES_SOURCE_REVISION: &str = "cfc3e01d5f79baf41374c75e0afface8c464c699";
 
 pub static SERVICE_ALIAS_RULES: &[ServiceAliasRule] = &[
     ServiceAliasRule {

--- a/crates/scryer-rules/Cargo.toml
+++ b/crates/scryer-rules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-rules"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-runtime-info/Cargo.toml
+++ b/crates/scryer-runtime-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-runtime-info"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer-webauthn/Cargo.toml
+++ b/crates/scryer-webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer-webauthn"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [dependencies]

--- a/crates/scryer/Cargo.toml
+++ b/crates/scryer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scryer"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 
 [features]

--- a/release-notes/scryer-v0.19.17.md
+++ b/release-notes/scryer-v0.19.17.md
@@ -6,6 +6,7 @@
 
 ## Included fixes
 
+- Deleting a title together with its files works for titles in any library. The delete guard compared the title folder against the root folders of the facet's default library only, so a title in a second library of the same kind (a separate Anime or Movies library with its own root) was always refused with "outside the configured root folders". The guard now checks the roots of the library the title belongs to.
 - Connecting a Jellyfin media server works with either an admin login or a pasted API key. The admin login path can once again read and create Scryer's API key on the server.
 - Jellyfin user lists load, so Jellyfin users can be added and given access to requests again.
 - Jellyfin account links and logins verify against the server again.

--- a/release-notes/scryer-v0.19.17.md
+++ b/release-notes/scryer-v0.19.17.md
@@ -4,8 +4,12 @@
 
 - Jellyfin 12 servers work again. Jellyfin 12 stopped accepting the `X-Emby-Token` header Scryer authenticated with, so every call Scryer made to a Jellyfin 12 server came back unauthorized: connecting a media server, listing its users, linking accounts and scanning the library all failed, typically showing `unauthorized: Jellyfin admin token cannot list API keys` when adding the connection. This closes issue #211. Scryer now authenticates with the `Authorization: MediaBrowser` header that Jellyfin 12 requires.
 
+- Library scans recover titles whose folder moved outside Scryer. When files were relocated to another root folder by a different tool (a root-folder move, a drive migration, a root split), every affected title surfaced as a pending import with the reason "title already owns another folder" on every scan, and the scan dropped the title's catalog files, which could leave monitored titles looking missing. Scryer now notices that the recorded folder is gone while its root is still populated, re-points the title at the folder the files actually live in, and keeps the catalog files. Affected libraries heal on their next full scan; the pending imports clear themselves.
+
 ## Included fixes
 
+- A title whose recorded folder no longer exists is re-pointed at the folder a scan finds its files in, for both movies and series. This only happens when the old folder's parent directory is still populated; a root that is missing or empty is treated as an unmounted drive and left alone.
+- Scans no longer remove a title's catalog files over a folder-ownership conflict unless the folder the title owns is confirmed to still exist. A conflict against a vanished or unreachable folder keeps the files, so the title is not treated as missing and re-downloaded.
 - Deleting a title together with its files works for titles in any library. The delete guard compared the title folder against the root folders of the facet's default library only, so a title in a second library of the same kind (a separate Anime or Movies library with its own root) was always refused with "outside the configured root folders". The guard now checks the roots of the library the title belongs to.
 - Connecting a Jellyfin media server works with either an admin login or a pasted API key. The admin login path can once again read and create Scryer's API key on the server.
 - Jellyfin user lists load, so Jellyfin users can be added and given access to requests again.

--- a/release-notes/scryer-v0.19.17.md
+++ b/release-notes/scryer-v0.19.17.md
@@ -10,7 +10,8 @@
 - Jellyfin user lists load, so Jellyfin users can be added and given access to requests again.
 - Jellyfin account links and logins verify against the server again.
 - Jellyfin library scans authenticate again, so Scryer can see what is already in the library and stops treating owned titles as missing.
-- Jellyfin 10.x servers and Emby servers are unaffected: Scryer sends both the new and the previous credential on every request, so no server generation needs a different setting.
+- Jellyfin 10.x servers keep working: Scryer sends both the new and the previous credential on every Jellyfin request, so no Jellyfin generation needs a different setting.
+- Emby servers are untouched. Emby keeps its own credential path and request code, separate from Jellyfin, so this change sends nothing new to an Emby server.
 
 ## Upgrading
 

--- a/release-notes/scryer-v0.19.17.md
+++ b/release-notes/scryer-v0.19.17.md
@@ -1,0 +1,19 @@
+# Scryer 0.19.17 release notes
+
+## Highlights
+
+- Jellyfin 12 servers work again. Jellyfin 12 stopped accepting the `X-Emby-Token` header Scryer authenticated with, so every call Scryer made to a Jellyfin 12 server came back unauthorized: connecting a media server, listing its users, linking accounts and scanning the library all failed, typically showing `unauthorized: Jellyfin admin token cannot list API keys` when adding the connection. This closes issue #211. Scryer now authenticates with the `Authorization: MediaBrowser` header that Jellyfin 12 requires.
+
+## Included fixes
+
+- Connecting a Jellyfin media server works with either an admin login or a pasted API key. The admin login path can once again read and create Scryer's API key on the server.
+- Jellyfin user lists load, so Jellyfin users can be added and given access to requests again.
+- Jellyfin account links and logins verify against the server again.
+- Jellyfin library scans authenticate again, so Scryer can see what is already in the library and stops treating owned titles as missing.
+- Jellyfin 10.x servers and Emby servers are unaffected: Scryer sends both the new and the previous credential on every request, so no server generation needs a different setting.
+
+## Upgrading
+
+No migration. No configuration changes.
+
+If you turned on **Enable legacy authorization** in your Jellyfin server's settings to work around this, you no longer need it and can turn it off again.

--- a/release-notes/scryer-v0.19.17.md
+++ b/release-notes/scryer-v0.19.17.md
@@ -6,17 +6,19 @@
 
 - Library scans recover titles whose folder moved outside Scryer. When files were relocated to another root folder by a different tool (a root-folder move, a drive migration, a root split), every affected title surfaced as a pending import with the reason "title already owns another folder" on every scan, and the scan dropped the title's catalog files, which could leave monitored titles looking missing. Scryer now notices that the recorded folder is gone while its root is still populated, re-points the title at the folder the files actually live in, and keeps the catalog files. Affected libraries heal on their next full scan; the pending imports clear themselves.
 
+- Deleting a title together with its files works in every library. The delete guard compared the title's folder against the root folders of the facet's default library only, so a title in a second library of the same kind — a separate Anime or Movies library with its own root — was always refused with "outside the configured root folders". The guard now checks the roots of the library the title actually belongs to.
+
 ## Included fixes
 
 - A title whose recorded folder no longer exists is re-pointed at the folder a scan finds its files in, for both movies and series. This only happens when the old folder's parent directory is still populated; a root that is missing or empty is treated as an unmounted drive and left alone.
 - Scans no longer remove a title's catalog files over a folder-ownership conflict unless the folder the title owns is confirmed to still exist. A conflict against a vanished or unreachable folder keeps the files, so the title is not treated as missing and re-downloaded.
-- Deleting a title together with its files works for titles in any library. The delete guard compared the title folder against the root folders of the facet's default library only, so a title in a second library of the same kind (a separate Anime or Movies library with its own root) was always refused with "outside the configured root folders". The guard now checks the roots of the library the title belongs to.
 - Connecting a Jellyfin media server works with either an admin login or a pasted API key. The admin login path can once again read and create Scryer's API key on the server.
 - Jellyfin user lists load, so Jellyfin users can be added and given access to requests again.
 - Jellyfin account links and logins verify against the server again.
 - Jellyfin library scans authenticate again, so Scryer can see what is already in the library and stops treating owned titles as missing.
 - Jellyfin 10.x servers keep working: Scryer sends both the new and the previous credential on every Jellyfin request, so no Jellyfin generation needs a different setting.
-- Emby servers are untouched. Emby keeps its own credential path and request code, separate from Jellyfin, so this change sends nothing new to an Emby server.
+- Emby servers are unaffected. Emby keeps its own credential path and its own request code, separate from Jellyfin, so no Jellyfin credential is ever sent to an Emby server.
+- TRaSH Guides data is refreshed to 828 active release-group rules. The release group `HHWEB` is no longer part of WEB Tier 03 for movies or series, following the upstream guide change; it is not scored as another tier instead. Every score set keeps its existing minimum, maximum and veto values.
 
 ## Upgrading
 

--- a/test-plugins/test-indexer/Cargo.lock
+++ b/test-plugins/test-indexer/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "syn"
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
+version = "0.25.15+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+checksum = "1340ea94a5856333492c9064b02c778b191dd2c853778d9609debdcdfea3a614"
 dependencies = [
  "indexmap",
  "toml_datetime",

--- a/xtask-trash-guides/Cargo.toml
+++ b/xtask-trash-guides/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask-trash-guides"
-version = "0.19.16"
+version = "0.19.17"
 edition = "2024"
 publish = false
 

--- a/xtask-trash-guides/generated/latest-summary.txt
+++ b/xtask-trash-guides/generated/latest-summary.txt
@@ -1,8 +1,8 @@
 TRaSH Guides sync summary
-Source revision: 31a2716d03a3f554a5a2a6bd76456109d900af05
+Source revision: cfc3e01d5f79baf41374c75e0afface8c464c699
 
-Active release-group rules: 830
-  by facet: movies=277, series=175, anime=378
+Active release-group rules: 828
+  by facet: movies=276, series=174, anime=378
 Active service aliases: 100
 Active parser token signals: 29
 Active guide facts: 132
@@ -10,4 +10,4 @@ Active language rules: 17
 Active blocked title rules: 55
   by facet: movies=10, series=5, anime=40
 Preserved inactive records: 433
-Ignored records: 757
+Ignored records: 759

--- a/xtask-trash-guides/generated/stem-classification.json
+++ b/xtask-trash-guides/generated/stem-classification.json
@@ -1,5 +1,5 @@
 {
-  "source_revision": "31a2716d03a3f554a5a2a6bd76456109d900af05",
+  "source_revision": "cfc3e01d5f79baf41374c75e0afface8c464c699",
   "score_envelope": [
     {
       "score_set": "anime-radarr",
@@ -2628,9 +2628,9 @@
       "detection_owner": "existing_native",
       "effect_binding": "persona_score",
       "reason": "reviewed_release_group_tier",
-      "emitted_rule_count": 10,
+      "emitted_rule_count": 9,
       "emitted_fact_codes": [],
-      "emitted_rule_digest": "fnv1a64:db2eef88d6fcd75a"
+      "emitted_rule_digest": "fnv1a64:bf82602d3509985c"
     },
     {
       "app": "radarr",
@@ -5126,9 +5126,9 @@
       "detection_owner": "existing_native",
       "effect_binding": "persona_score",
       "reason": "reviewed_release_group_tier",
-      "emitted_rule_count": 9,
+      "emitted_rule_count": 8,
       "emitted_fact_codes": [],
-      "emitted_rule_digest": "fnv1a64:b77edeb7835bcddc"
+      "emitted_rule_digest": "fnv1a64:6fecd15d2fb1f769"
     },
     {
       "app": "sonarr",
@@ -9661,6 +9661,26 @@
       "cf_name": "126811",
       "spec_name": "126811",
       "implementation": "ReleaseGroupSpecification",
+      "reason": "unsupported_unreviewed_stem",
+      "source_path": "docs/json/radarr/cf/126811.json"
+    },
+    {
+      "app": "radarr",
+      "stem": "126811",
+      "trash_id": "9681750c690210f0936faed781bb7f06",
+      "cf_name": "126811",
+      "spec_name": "Internal",
+      "implementation": "IndexerFlagSpecification",
+      "reason": "unsupported_unreviewed_stem",
+      "source_path": "docs/json/radarr/cf/126811.json"
+    },
+    {
+      "app": "radarr",
+      "stem": "126811",
+      "trash_id": "9681750c690210f0936faed781bb7f06",
+      "cf_name": "126811",
+      "spec_name": "Not ATMO5/ATM05 Collab",
+      "implementation": "ReleaseTitleSpecification",
       "reason": "unsupported_unreviewed_stem",
       "source_path": "docs/json/radarr/cf/126811.json"
     },


### PR DESCRIPTION
Release branch for Scryer 0.19.17. Full operator-facing notes: `release-notes/scryer-v0.19.17.md`.

## Jellyfin 12 authentication (closes #211)

Jellyfin 12 stopped accepting the `X-Emby-Token` header Scryer authenticated with, so every Jellyfin 12 call came back unauthorized — connecting a server, listing its users, linking accounts and scanning the library all failed, usually surfacing as `unauthorized: Jellyfin admin token cannot list API keys`.

- Scryer now sends the `Authorization: MediaBrowser` header Jellyfin 12 requires, alongside the previous credential, so Jellyfin 10.x keeps working with no setting to change.
- Jellyfin and Emby were split into separate request paths, so nothing new is sent to an Emby server.

Operators who enabled **Enable legacy authorization** on the Jellyfin server as a workaround can turn it back off.

## Library scan heals relocated title folders

When files were moved to another root by an outside tool (root-folder move, drive migration, root split), every affected title surfaced as a pending import reading "title already owns another folder" on every scan, and the scan dropped the title's catalog files — leaving monitored titles looking missing and eligible for re-download.

- A title whose recorded folder is gone is re-pointed at the folder the scan actually finds its files in, for movies and series.
- This only applies when the old folder's parent directory is still populated. A missing or empty root is treated as an unmounted drive and left alone.
- Catalog files are no longer removed over a folder-ownership conflict unless the owned folder is confirmed to still exist.

Affected libraries heal on their next full scan and the pending imports clear themselves.

## Delete guard uses the title's own library roots

Deleting a title together with its files was refused with "outside the configured root folders" for any title in a non-default library of its facet, because the guard compared the folder against the facet default library's roots only. It now checks the roots of the library the title actually belongs to.

## Also included

- TRaSH Guides data refreshed to `cfc3e01`.

## Branch state

Eight signed commits ahead of `main`; no content on `main` is missing from this branch. Already forward-merged into `release-0.20.0`.
